### PR TITLE
Add Naval Clash multiplayer backend with encrypted transport

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -52,3 +52,18 @@ NC_DB_PASSWORD=your_password_here
 # Alternative: use shared credentials with db_nc_* prefix
 # db_nc_user=navalclash_user
 # db_nc_password=your_password_here
+
+# =============================================================================
+# Naval Clash RSA Keys (for handshake encryption)
+# =============================================================================
+
+# Paths to RSA private key files (PEM format)
+# Index must match the key index in client's ServerKeyConfig
+NAVAL_RSA_PRIVATE_KEY_PATH_0=./keys/server_private_v1.pem
+NAVAL_RSA_PRIVATE_KEY_PATH_1=./keys/server_private_v2.pem
+NAVAL_RSA_PRIVATE_KEY_PATH_2=./keys/server_private_v3.pem
+NAVAL_RSA_PRIVATE_KEY_PATH_3=./keys/server_private_v4.pem
+
+# HMAC token signing secret (base64-encoded 32 bytes)
+# Generate with: openssl rand -base64 32 > ./keys/token_secret.txt
+NAVAL_TOKEN_SECRET_PATH=./keys/token_secret.txt

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .env
 .env.*
 !.env.sample
+/keys/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,13 @@ const { logger } = require("../../utils/logger")
 ### Log Format
 
 All logs automatically include timestamp, process ID, and worker ID:
+
 ```
 YYYY-MM-DD HH:mm:ss.SSS pid:workerId: LEVEL [context] message
 ```
 
 Example output:
+
 ```
 2026-01-10 14:32:15.123 12345:2: INFO [sid=115873854376116224 uid=42] User connected successfully
 ```
@@ -30,6 +32,7 @@ Example output:
 - `ERROR` - Failures requiring attention (database errors, invalid requests)
 
 Set log level via environment variable:
+
 ```
 LOG_LEVEL=INFO  # Only show INFO, WARN, ERROR
 LOG_LEVEL=DEBUG # Show all logs (default)
@@ -48,6 +51,7 @@ logger.info({}, "User connected")
 ```
 
 Common context fields:
+
 - `reqId` - Request ID (8-char UUID, set by middleware on `req.requestId`)
 - `sid` - Session ID (full BigInt as string)
 - `uid` - User ID
@@ -60,6 +64,7 @@ Common context fields:
 ### Logging Patterns
 
 #### Entry points (request handlers)
+
 ```javascript
 async function connect(req, res) {
     const ctx = { uid: req.body.uid }
@@ -70,6 +75,7 @@ async function connect(req, res) {
 ```
 
 #### Decision points
+
 ```javascript
 if (existingSession) {
     logger.debug(ctx, "Found existing session, joining")
@@ -79,6 +85,7 @@ if (existingSession) {
 ```
 
 #### Errors
+
 ```javascript
 try {
     // ... operation
@@ -89,9 +96,14 @@ try {
 ```
 
 #### IPC/Cluster communication
+
 ```javascript
 logger.debug(
-    { sid: sessionId, reqId: requestId?.substring(0, 8), workerId: poll.workerId },
+    {
+        sid: sessionId,
+        reqId: requestId?.substring(0, 8),
+        workerId: poll.workerId,
+    },
     "Waking receiver poll"
 )
 ```
@@ -105,20 +117,22 @@ const { createLogger } = require("../../utils/logger")
 
 function handleRequest(req, res) {
     const log = createLogger({ reqId: req.requestId, uid: req.body.uid })
-    log.info({}, "Processing request")  // Includes reqId and uid automatically
-    log.debug({ step: 1 }, "Step 1 complete")  // Merges contexts
+    log.info({}, "Processing request") // Includes reqId and uid automatically
+    log.debug({ step: 1 }, "Step 1 complete") // Merges contexts
 }
 ```
 
 ## Session ID Conventions
 
 Session IDs use a Snowflake-style format:
+
 - 48-bit timestamp
 - 10-bit worker ID
 - 5-bit sequence
 - 1-bit player indicator (last bit)
 
 Player identification:
+
 - Even session ID = Player 0
 - Odd session ID = Player 1
 - Opponent's session ID = `sessionId XOR 1`

--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ const numWorkers = parseInt(process.env.CLUSTER_WORKERS, 10) || os.cpus().length
 
 if (cluster.isMaster) {
     const { setupMasterBroker } = require("./services/navalclash/clusterBroker")
+    const { startSessionPurge } = require("./services/navalclash/sessionPurge")
 
     let nextWorkerId = 1
 
@@ -25,6 +26,9 @@ if (cluster.isMaster) {
 
     // Setup Naval Clash cluster broker for message passing
     setupMasterBroker()
+
+    // Start background session purge job (cleans stale sessions every 60s)
+    startSessionPurge()
 
     // Handle cert reload broadcast from workers
     cluster.on("message", (worker, message) => {

--- a/db/navalclash/index.js
+++ b/db/navalclash/index.js
@@ -13,6 +13,7 @@ const social = require("./social")
 const leaderboard = require("./leaderboard")
 const shop = require("./shop")
 const training = require("./training")
+const weapons = require("./weapons")
 
 module.exports = {
     pool,
@@ -24,4 +25,5 @@ module.exports = {
     ...leaderboard,
     ...shop,
     ...training,
+    ...weapons,
 }

--- a/db/navalclash/index.js
+++ b/db/navalclash/index.js
@@ -14,6 +14,7 @@ const leaderboard = require("./leaderboard")
 const shop = require("./shop")
 const training = require("./training")
 const weapons = require("./weapons")
+const keys = require("./keys")
 
 module.exports = {
     pool,
@@ -26,4 +27,5 @@ module.exports = {
     ...shop,
     ...training,
     ...weapons,
+    ...keys,
 }

--- a/db/navalclash/index.test.js
+++ b/db/navalclash/index.test.js
@@ -79,4 +79,15 @@ describe("db/navalclash/index", () => {
         expect(db.dbGetCoins).toBeDefined()
         expect(db.dbGetInventory).toBeDefined()
     })
+
+    it("should export weapons functions", () => {
+        const db = require("./index")
+        expect(db.dbGetUserWeaponInventory).toBeDefined()
+        expect(db.dbGetTrackedWeapons).toBeDefined()
+        expect(db.dbSetTrackedWeapons).toBeDefined()
+        expect(db.dbGetWeaponUsage).toBeDefined()
+        expect(db.dbIncrementWeaponUsage).toBeDefined()
+        expect(db.dbConsumeWeapons).toBeDefined()
+        expect(db.dbGetSessionUserId).toBeDefined()
+    })
 })

--- a/db/navalclash/index.test.js
+++ b/db/navalclash/index.test.js
@@ -89,5 +89,6 @@ describe("db/navalclash/index", () => {
         expect(db.dbIncrementWeaponUsage).toBeDefined()
         expect(db.dbConsumeWeapons).toBeDefined()
         expect(db.dbGetSessionUserId).toBeDefined()
+        expect(db.dbGetUserWeaponArrays).toBeDefined()
     })
 })

--- a/db/navalclash/keys.js
+++ b/db/navalclash/keys.js
@@ -1,0 +1,175 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ */
+
+const { pool } = require("./pool")
+
+const LRU_CACHE_SIZE = 30
+
+/**
+ * Simple LRU cache for device keys.
+ * Each server worker has its own cache instance.
+ */
+class DeviceKeyCache {
+    /**
+     * @param {number} maxSize - Maximum cache entries
+     */
+    constructor(maxSize = LRU_CACHE_SIZE) {
+        this.maxSize = maxSize
+        this.cache = new Map() // Map maintains insertion order
+    }
+
+    /**
+     * Gets a key from cache, promoting to most-recently-used.
+     *
+     * @param {string} tokenBase64 - Device token
+     * @returns {{ key: Buffer, deviceUuid: string } | null}
+     */
+    get(tokenBase64) {
+        if (!this.cache.has(tokenBase64)) {
+            return null
+        }
+        const value = this.cache.get(tokenBase64)
+        this.cache.delete(tokenBase64)
+        this.cache.set(tokenBase64, value)
+        return value
+    }
+
+    /**
+     * Adds a key to cache, evicting LRU entry if at capacity.
+     *
+     * @param {string} tokenBase64 - Device token
+     * @param {Buffer} key - AES key
+     * @param {string} deviceUuid - Device UUID
+     */
+    set(tokenBase64, key, deviceUuid) {
+        if (this.cache.has(tokenBase64)) {
+            this.cache.delete(tokenBase64)
+        }
+        if (this.cache.size >= this.maxSize) {
+            const lruKey = this.cache.keys().next().value
+            this.cache.delete(lruKey)
+        }
+        this.cache.set(tokenBase64, { key, deviceUuid })
+    }
+
+    /**
+     * Removes a key from cache.
+     *
+     * @param {string} tokenBase64 - Device token
+     */
+    delete(tokenBase64) {
+        this.cache.delete(tokenBase64)
+    }
+
+    /**
+     * Clears the entire cache.
+     */
+    clear() {
+        this.cache.clear()
+    }
+
+    /**
+     * Returns current cache size.
+     *
+     * @returns {number}
+     */
+    get size() {
+        return this.cache.size
+    }
+}
+
+// Singleton instance per server process
+const deviceKeyCache = new DeviceKeyCache()
+
+/**
+ * Gets device key, checking LRU cache first.
+ *
+ * @param {string} tokenBase64 - Base64-encoded device token
+ * @returns {Promise<{ key: Buffer, deviceUuid: string } | null>}
+ */
+async function dbGetDeviceKey(tokenBase64) {
+    const cached = deviceKeyCache.get(tokenBase64)
+    if (cached) {
+        return cached
+    }
+
+    try {
+        const [rows] = await pool.execute(
+            `SELECT device_key, device_uuid FROM device_keys
+             WHERE device_token = ? AND expires_at > NOW()`,
+            [tokenBase64]
+        )
+
+        if (rows.length === 0) {
+            return null
+        }
+
+        const result = {
+            key: rows[0].device_key,
+            deviceUuid: rows[0].device_uuid,
+        }
+
+        deviceKeyCache.set(tokenBase64, result.key, result.deviceUuid)
+        return result
+    } catch (error) {
+        console.error("dbGetDeviceKey error:", error)
+        return null
+    }
+}
+
+/**
+ * Stores device key in database and cache.
+ *
+ * @param {string} tokenBase64 - Base64-encoded device token
+ * @param {Buffer} key - 32-byte AES key
+ * @param {string} deviceUuid - Device UUID
+ * @param {number} ttlSeconds - Time to live in seconds
+ * @returns {Promise<boolean>} True if stored successfully
+ */
+async function dbStoreDeviceKey(tokenBase64, key, deviceUuid, ttlSeconds) {
+    try {
+        await pool.execute(
+            `INSERT INTO device_keys
+                (device_token, device_key, device_uuid, expires_at)
+             VALUES (?, ?, ?, DATE_ADD(NOW(), INTERVAL ? SECOND))
+             ON DUPLICATE KEY UPDATE
+                device_key = VALUES(device_key),
+                expires_at = VALUES(expires_at)`,
+            [tokenBase64, key, deviceUuid, ttlSeconds]
+        )
+
+        deviceKeyCache.set(tokenBase64, key, deviceUuid)
+        return true
+    } catch (error) {
+        console.error("dbStoreDeviceKey error:", error)
+        return false
+    }
+}
+
+/**
+ * Deletes expired device keys from database.
+ *
+ * @returns {Promise<number>} Number of deleted rows
+ */
+async function dbCleanupExpiredKeys() {
+    try {
+        const [result] = await pool.execute(
+            "DELETE FROM device_keys WHERE expires_at < NOW()"
+        )
+        return result.affectedRows || 0
+    } catch (error) {
+        console.error("dbCleanupExpiredKeys error:", error)
+        return 0
+    }
+}
+
+module.exports = {
+    DeviceKeyCache,
+    deviceKeyCache,
+    dbGetDeviceKey,
+    dbStoreDeviceKey,
+    dbCleanupExpiredKeys,
+}

--- a/db/navalclash/keys.test.js
+++ b/db/navalclash/keys.test.js
@@ -1,0 +1,196 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ */
+
+const mockExecute = jest.fn()
+
+jest.mock("./pool", () => ({
+    pool: { execute: mockExecute },
+}))
+
+const {
+    DeviceKeyCache,
+    dbGetDeviceKey,
+    dbStoreDeviceKey,
+    dbCleanupExpiredKeys,
+} = require("./keys")
+
+describe("DeviceKeyCache", () => {
+    let cache
+
+    beforeEach(() => {
+        cache = new DeviceKeyCache(3)
+    })
+
+    it("should return null for missing key", () => {
+        expect(cache.get("missing")).toBeNull()
+    })
+
+    it("should store and retrieve a key", () => {
+        const key = Buffer.from("test-key")
+        cache.set("token1", key, "device-uuid-1")
+
+        const result = cache.get("token1")
+        expect(result.key).toEqual(key)
+        expect(result.deviceUuid).toBe("device-uuid-1")
+    })
+
+    it("should evict LRU entry when at capacity", () => {
+        cache.set("a", Buffer.from("ka"), "da")
+        cache.set("b", Buffer.from("kb"), "db")
+        cache.set("c", Buffer.from("kc"), "dc")
+
+        // Cache is full (3), adding d should evict a (LRU)
+        cache.set("d", Buffer.from("kd"), "dd")
+
+        expect(cache.get("a")).toBeNull()
+        expect(cache.get("b")).not.toBeNull()
+        expect(cache.get("d")).not.toBeNull()
+    })
+
+    it("should promote accessed entry to MRU", () => {
+        cache.set("a", Buffer.from("ka"), "da")
+        cache.set("b", Buffer.from("kb"), "db")
+        cache.set("c", Buffer.from("kc"), "dc")
+
+        // Access a (promotes to MRU)
+        cache.get("a")
+
+        // Add d - should evict b (now LRU), not a
+        cache.set("d", Buffer.from("kd"), "dd")
+
+        expect(cache.get("a")).not.toBeNull()
+        expect(cache.get("b")).toBeNull()
+    })
+
+    it("should update existing entry", () => {
+        const key1 = Buffer.from("key1")
+        const key2 = Buffer.from("key2")
+
+        cache.set("token1", key1, "uuid1")
+        cache.set("token1", key2, "uuid2")
+
+        const result = cache.get("token1")
+        expect(result.key).toEqual(key2)
+        expect(result.deviceUuid).toBe("uuid2")
+        expect(cache.size).toBe(1)
+    })
+
+    it("should delete a key", () => {
+        cache.set("token1", Buffer.from("key"), "uuid")
+        cache.delete("token1")
+        expect(cache.get("token1")).toBeNull()
+    })
+
+    it("should clear all entries", () => {
+        cache.set("a", Buffer.from("ka"), "da")
+        cache.set("b", Buffer.from("kb"), "db")
+        cache.clear()
+        expect(cache.size).toBe(0)
+    })
+})
+
+describe("dbGetDeviceKey", () => {
+    beforeEach(() => {
+        mockExecute.mockReset()
+    })
+
+    it("should return key from database", async () => {
+        const mockKey = Buffer.from("a".repeat(32))
+        mockExecute.mockResolvedValue([
+            [{ device_key: mockKey, device_uuid: "test-uuid" }],
+        ])
+
+        const result = await dbGetDeviceKey("token-base64")
+
+        expect(result).toEqual({ key: mockKey, deviceUuid: "test-uuid" })
+        expect(mockExecute).toHaveBeenCalledWith(
+            expect.stringContaining("SELECT device_key"),
+            ["token-base64"]
+        )
+    })
+
+    it("should return null when token not found", async () => {
+        mockExecute.mockResolvedValue([[]])
+
+        const result = await dbGetDeviceKey("missing-token")
+        expect(result).toBeNull()
+    })
+
+    it("should return null on database error", async () => {
+        mockExecute.mockRejectedValue(new Error("DB connection failed"))
+
+        const result = await dbGetDeviceKey("error-token")
+        expect(result).toBeNull()
+    })
+
+    it("should use cache on second access", async () => {
+        const mockKey = Buffer.from("b".repeat(32))
+        mockExecute.mockResolvedValue([
+            [{ device_key: mockKey, device_uuid: "cached-uuid" }],
+        ])
+
+        // First call hits DB
+        await dbGetDeviceKey("cached-token")
+        expect(mockExecute).toHaveBeenCalledTimes(1)
+
+        // Second call should use cache
+        mockExecute.mockReset()
+        const result = await dbGetDeviceKey("cached-token")
+        expect(result).toEqual({ key: mockKey, deviceUuid: "cached-uuid" })
+        expect(mockExecute).not.toHaveBeenCalled()
+    })
+})
+
+describe("dbStoreDeviceKey", () => {
+    beforeEach(() => {
+        mockExecute.mockReset()
+    })
+
+    it("should store key in database", async () => {
+        mockExecute.mockResolvedValue([{ affectedRows: 1 }])
+
+        const key = Buffer.from("c".repeat(32))
+        const result = await dbStoreDeviceKey("token-b64", key, "uuid", 3600)
+
+        expect(result).toBe(true)
+        expect(mockExecute).toHaveBeenCalledWith(
+            expect.stringContaining("INSERT INTO device_keys"),
+            ["token-b64", key, "uuid", 3600]
+        )
+    })
+
+    it("should return false on database error", async () => {
+        mockExecute.mockRejectedValue(new Error("DB error"))
+
+        const key = Buffer.from("d".repeat(32))
+        const result = await dbStoreDeviceKey("token", key, "uuid", 3600)
+
+        expect(result).toBe(false)
+    })
+})
+
+describe("dbCleanupExpiredKeys", () => {
+    beforeEach(() => {
+        mockExecute.mockReset()
+    })
+
+    it("should delete expired keys and return count", async () => {
+        mockExecute.mockResolvedValue([{ affectedRows: 5 }])
+
+        const count = await dbCleanupExpiredKeys()
+        expect(count).toBe(5)
+        expect(mockExecute).toHaveBeenCalledWith(
+            expect.stringContaining("DELETE FROM device_keys")
+        )
+    })
+
+    it("should return 0 on error", async () => {
+        mockExecute.mockRejectedValue(new Error("DB error"))
+
+        const count = await dbCleanupExpiredKeys()
+        expect(count).toBe(0)
+    })
+})

--- a/db/navalclash/leaderboard.js
+++ b/db/navalclash/leaderboard.js
@@ -6,26 +6,68 @@
 
 const { pool } = require("./pool")
 
+// Score validation thresholds
+const TOPSCORE_THRESHOLD = 3000 // Minimum score to be recorded
+const MIN_GAME_TIME_MS = 30000 // Minimum game duration (30 seconds)
+
 /**
- * Gets top scores for a game variant and type.
+ * Gets top scores for a game variant with deduplication.
+ * Fetches top 50 vs Android (game_type=1) + top 50 vs Human (game_type 2,3,4).
+ * Returns max 1 score per player per category, sorted by score DESC.
  *
  * @param {number} gameVariant - Game variant
- * @param {number} gameType - Game type (1=android, 2=bt, 3=web, 4=passplay)
- * @param {number} limit - Max results
- * @returns {Promise<Array>} Array of score objects
+ * @param {number} limitPerType - Max results per game type category (default 50)
+ * @returns {Promise<Array>} Array of score objects (up to 100 total)
  */
-async function dbGetTopScores(gameVariant, gameType, limit) {
+async function dbGetTopScores(gameVariant, limitPerType = 50) {
     try {
-        const [rows] = await pool.execute(
-            `SELECT ts.*, u.name, u.face, u.uuid
+        // Fetch top scores vs Android (game_type = 1)
+        // Use query() instead of execute() to avoid prepared statement issues with LIMIT
+        const [androidRows] = await pool.query(
+            `SELECT ts.*, u.name, u.face, u.uuid,
+                    o.name AS opponent_name, o.face AS opponent_face
              FROM topscores ts
              JOIN users u ON u.id = ts.user_id
-             WHERE ts.game_variant = ? AND ts.game_type = ?
-             ORDER BY ts.score DESC
+             LEFT JOIN users o ON o.id = ts.opponent_id
+             INNER JOIN (
+                 SELECT user_id, MAX(score) as max_score
+                 FROM topscores
+                 WHERE game_variant = ? AND game_type = 1
+                 GROUP BY user_id
+             ) best ON ts.user_id = best.user_id AND ts.score = best.max_score
+             WHERE ts.game_variant = ? AND ts.game_type = 1
+             ORDER BY ts.score DESC, ts.created_at ASC
              LIMIT ?`,
-            [gameVariant, gameType, limit]
+            [gameVariant, gameVariant, Number(limitPerType)]
         )
-        return rows
+
+        // Fetch top scores vs Human (game_type IN (2,3,4) - bt, web, passplay)
+        const [humanRows] = await pool.query(
+            `SELECT ts.*, u.name, u.face, u.uuid,
+                    o.name AS opponent_name, o.face AS opponent_face
+             FROM topscores ts
+             JOIN users u ON u.id = ts.user_id
+             LEFT JOIN users o ON o.id = ts.opponent_id
+             INNER JOIN (
+                 SELECT user_id, MAX(score) as max_score
+                 FROM topscores
+                 WHERE game_variant = ? AND game_type IN (2, 3, 4)
+                 GROUP BY user_id
+             ) best ON ts.user_id = best.user_id AND ts.score = best.max_score
+             WHERE ts.game_variant = ? AND ts.game_type IN (2, 3, 4)
+             ORDER BY ts.score DESC, ts.created_at ASC
+             LIMIT ?`,
+            [gameVariant, gameVariant, Number(limitPerType)]
+        )
+
+        // Combine and sort by score DESC
+        const combined = [...androidRows, ...humanRows]
+        combined.sort((a, b) => {
+            if (b.score !== a.score) return b.score - a.score
+            return new Date(a.created_at) - new Date(b.created_at)
+        })
+
+        return combined
     } catch (error) {
         console.error("dbGetTopScores error:", error)
         return []
@@ -33,7 +75,67 @@ async function dbGetTopScores(gameVariant, gameType, limit) {
 }
 
 /**
- * Submits a new score.
+ * Gets top scores filtered by game type with deduplication.
+ *
+ * @param {number} gameVariant - Game variant
+ * @param {number} gameType - Game type (1=android, 2=bt, 3=web, 4=passplay)
+ * @param {number} limit - Max results
+ * @returns {Promise<Array>} Array of score objects
+ */
+async function dbGetTopScoresByType(gameVariant, gameType, limit) {
+    try {
+        // Note: Use query() instead of execute() to avoid prepared statement issues with LIMIT
+        const [rows] = await pool.query(
+            `SELECT ts.*, u.name, u.face, u.uuid,
+                    o.name AS opponent_name, o.face AS opponent_face
+             FROM topscores ts
+             JOIN users u ON u.id = ts.user_id
+             LEFT JOIN users o ON o.id = ts.opponent_id
+             INNER JOIN (
+                 SELECT user_id, MAX(score) as max_score
+                 FROM topscores
+                 WHERE game_variant = ? AND game_type = ?
+                 GROUP BY user_id
+             ) best ON ts.user_id = best.user_id AND ts.score = best.max_score
+             WHERE ts.game_variant = ? AND ts.game_type = ?
+             ORDER BY ts.score DESC, ts.created_at ASC
+             LIMIT ?`,
+            [gameVariant, gameType, gameVariant, gameType, Number(limit)]
+        )
+        return rows
+    } catch (error) {
+        console.error("dbGetTopScoresByType error:", error)
+        return []
+    }
+}
+
+/**
+ * Checks if a score already exists for this user/score/rank combination.
+ * Used to prevent duplicate entries.
+ *
+ * @param {number} userId - User ID
+ * @param {number} score - Score value
+ * @param {number} userRank - User's rank
+ * @returns {Promise<boolean>} True if duplicate exists
+ */
+async function dbScoreExists(userId, score, userRank) {
+    try {
+        const [rows] = await pool.execute(
+            `SELECT id FROM topscores
+             WHERE user_id = ? AND score = ? AND user_rank = ?
+             LIMIT 1`,
+            [userId, score, userRank]
+        )
+        return rows.length > 0
+    } catch (error) {
+        console.error("dbScoreExists error:", error)
+        return true // Assume exists on error to be safe
+    }
+}
+
+/**
+ * Validates and submits a score to the leaderboard.
+ * Checks threshold, game duration, and duplicates before inserting.
  *
  * @param {Object} scoreData - Score data
  * @param {number} scoreData.userId - User ID
@@ -44,9 +146,35 @@ async function dbGetTopScores(gameVariant, gameType, limit) {
  * @param {number} scoreData.gameVariant - Game variant
  * @param {number} scoreData.userRank - User's rank
  * @param {number} scoreData.opponentRank - Opponent's rank
- * @returns {Promise<number|null>} New score ID or null on error
+ * @returns {Promise<Object>} Result object { success, reason, scoreId }
  */
 async function dbSubmitScore(scoreData) {
+    // Validate score threshold
+    if (scoreData.score < TOPSCORE_THRESHOLD) {
+        return {
+            success: false,
+            reason: `Score ${scoreData.score} below threshold ${TOPSCORE_THRESHOLD}`,
+        }
+    }
+
+    // Validate minimum game duration
+    if (scoreData.timeMs < MIN_GAME_TIME_MS) {
+        return {
+            success: false,
+            reason: `Game time ${scoreData.timeMs}ms below minimum ${MIN_GAME_TIME_MS}ms`,
+        }
+    }
+
+    // Check for duplicates
+    const exists = await dbScoreExists(
+        scoreData.userId,
+        scoreData.score,
+        scoreData.userRank
+    )
+    if (exists) {
+        return { success: false, reason: "Duplicate score" }
+    }
+
     try {
         const [result] = await pool.execute(
             `INSERT INTO topscores
@@ -63,14 +191,101 @@ async function dbSubmitScore(scoreData) {
                 scoreData.opponentRank,
             ]
         )
-        return result.insertId
+        return { success: true, scoreId: result.insertId }
     } catch (error) {
         console.error("dbSubmitScore error:", error)
+        return { success: false, reason: error.message }
+    }
+}
+
+/**
+ * Gets a user's best score.
+ *
+ * @param {number} userId - User ID
+ * @param {number} gameVariant - Game variant
+ * @returns {Promise<number>} Best score or 0 if none
+ */
+async function dbGetUserBestScore(userId, gameVariant) {
+    try {
+        const [rows] = await pool.execute(
+            `SELECT MAX(score) as best_score FROM topscores
+             WHERE user_id = ? AND game_variant = ?`,
+            [userId, gameVariant]
+        )
+        return rows.length > 0 && rows[0].best_score ? rows[0].best_score : 0
+    } catch (error) {
+        console.error("dbGetUserBestScore error:", error)
+        return 0
+    }
+}
+
+/**
+ * Gets a user's rank on the leaderboard.
+ *
+ * @param {number} userId - User ID
+ * @param {number} gameVariant - Game variant
+ * @returns {Promise<number|null>} Rank (1-based) or null if not ranked
+ */
+async function dbGetUserLeaderboardRank(userId, gameVariant) {
+    try {
+        // Get user's best score
+        const bestScore = await dbGetUserBestScore(userId, gameVariant)
+        if (!bestScore) return null
+
+        // Count how many users have a higher best score
+        const [rows] = await pool.execute(
+            `SELECT COUNT(DISTINCT user_id) as rank
+             FROM topscores
+             WHERE game_variant = ?
+               AND score > ?`,
+            [gameVariant, bestScore]
+        )
+        return rows.length > 0 ? rows[0].rank + 1 : null
+    } catch (error) {
+        console.error("dbGetUserLeaderboardRank error:", error)
         return null
+    }
+}
+
+/**
+ * Gets top players ranked by total stars.
+ * Returns players with highest star accumulation.
+ *
+ * @param {number} gameVariant - Game variant
+ * @param {number} limit - Max results
+ * @returns {Promise<Array>} Array of user objects ranked by stars
+ */
+async function dbGetTopStars(gameVariant, limit) {
+    try {
+        // Note: Use query() instead of execute() to avoid prepared statement issues with LIMIT
+        const [rows] = await pool.query(
+            `SELECT id, name, uuid, \`rank\`, stars, face,
+                    games, gameswon, version,
+                    games_android, games_bluetooth, games_web, games_passplay,
+                    wins_android, wins_bluetooth, wins_web, wins_passplay
+             FROM users
+             WHERE stars > 0
+               AND last_game_variant = ?
+             ORDER BY stars DESC, gameswon DESC
+             LIMIT ?`,
+            [gameVariant, Number(limit)]
+        )
+        return rows
+    } catch (error) {
+        console.error("dbGetTopStars error:", error)
+        return []
     }
 }
 
 module.exports = {
     dbGetTopScores,
+    dbGetTopScoresByType,
+    dbScoreExists,
     dbSubmitScore,
+    dbGetUserBestScore,
+    dbGetUserLeaderboardRank,
+    dbGetTopStars,
+    // Constants
+    TOPSCORE_THRESHOLD,
+    MIN_GAME_TIME_MS,
 }

--- a/db/navalclash/leaderboard.js
+++ b/db/navalclash/leaderboard.js
@@ -23,11 +23,12 @@ async function dbGetTopScores(gameVariant, limitPerType = 50) {
     try {
         // Fetch top scores vs Android (game_type = 1)
         // Use query() instead of execute() to avoid prepared statement issues with LIMIT
+        // Exclude banned users (isbanned = 1)
         const [androidRows] = await pool.query(
             `SELECT ts.*, u.name, u.face, u.uuid,
                     o.name AS opponent_name, o.face AS opponent_face
              FROM topscores ts
-             JOIN users u ON u.id = ts.user_id
+             JOIN users u ON u.id = ts.user_id AND u.isbanned = 0
              LEFT JOIN users o ON o.id = ts.opponent_id
              INNER JOIN (
                  SELECT user_id, MAX(score) as max_score
@@ -42,11 +43,12 @@ async function dbGetTopScores(gameVariant, limitPerType = 50) {
         )
 
         // Fetch top scores vs Human (game_type IN (2,3,4) - bt, web, passplay)
+        // Exclude banned users (isbanned = 1)
         const [humanRows] = await pool.query(
             `SELECT ts.*, u.name, u.face, u.uuid,
                     o.name AS opponent_name, o.face AS opponent_face
              FROM topscores ts
-             JOIN users u ON u.id = ts.user_id
+             JOIN users u ON u.id = ts.user_id AND u.isbanned = 0
              LEFT JOIN users o ON o.id = ts.opponent_id
              INNER JOIN (
                  SELECT user_id, MAX(score) as max_score
@@ -85,11 +87,12 @@ async function dbGetTopScores(gameVariant, limitPerType = 50) {
 async function dbGetTopScoresByType(gameVariant, gameType, limit) {
     try {
         // Note: Use query() instead of execute() to avoid prepared statement issues with LIMIT
+        // Exclude banned users (isbanned = 1)
         const [rows] = await pool.query(
             `SELECT ts.*, u.name, u.face, u.uuid,
                     o.name AS opponent_name, o.face AS opponent_face
              FROM topscores ts
-             JOIN users u ON u.id = ts.user_id
+             JOIN users u ON u.id = ts.user_id AND u.isbanned = 0
              LEFT JOIN users o ON o.id = ts.opponent_id
              INNER JOIN (
                  SELECT user_id, MAX(score) as max_score
@@ -258,6 +261,7 @@ async function dbGetUserLeaderboardRank(userId, gameVariant) {
 async function dbGetTopStars(gameVariant, limit) {
     try {
         // Note: Use query() instead of execute() to avoid prepared statement issues with LIMIT
+        // Exclude banned users (isbanned = 1)
         const [rows] = await pool.query(
             `SELECT id, name, uuid, \`rank\`, stars, face,
                     games, gameswon, version,
@@ -266,6 +270,7 @@ async function dbGetTopStars(gameVariant, limit) {
              FROM users
              WHERE stars > 0
                AND last_game_variant = ?
+               AND isbanned = 0
              ORDER BY stars DESC, gameswon DESC
              LIMIT ?`,
             [gameVariant, Number(limit)]

--- a/db/navalclash/leaderboard.test.js
+++ b/db/navalclash/leaderboard.test.js
@@ -5,62 +5,122 @@
  */
 
 const mockExecute = jest.fn()
+const mockQuery = jest.fn()
 
 jest.mock("./pool", () => ({
     pool: {
         execute: mockExecute,
+        query: mockQuery,
     },
 }))
 
-const { dbGetTopScores, dbSubmitScore } = require("./leaderboard")
+const {
+    dbGetTopScores,
+    dbGetTopScoresByType,
+    dbScoreExists,
+    dbSubmitScore,
+    dbGetUserBestScore,
+    dbGetUserLeaderboardRank,
+    dbGetTopStars,
+    TOPSCORE_THRESHOLD,
+    MIN_GAME_TIME_MS,
+} = require("./leaderboard")
 
 describe("db/navalclash/leaderboard", () => {
     beforeEach(() => {
         mockExecute.mockReset()
+        mockQuery.mockReset()
     })
 
     describe("dbGetTopScores", () => {
-        it("should return top scores", async () => {
-            const mockScores = [
-                { id: 1, score: 1000, user_id: 1, name: "Player1" },
-                { id: 2, score: 800, user_id: 2, name: "Player2" },
+        it("should return top scores from both Android and Human categories", async () => {
+            const androidScores = [
+                { id: 1, score: 5000, user_id: 1, name: "Player1", game_type: 1, created_at: new Date() },
             ]
-            mockExecute.mockResolvedValue([mockScores])
+            const humanScores = [
+                { id: 2, score: 4500, user_id: 2, name: "Player2", game_type: 3, created_at: new Date() },
+            ]
+            mockQuery
+                .mockResolvedValueOnce([androidScores]) // Android query
+                .mockResolvedValueOnce([humanScores]) // Human query
 
-            const result = await dbGetTopScores(1, 3, 10)
+            const result = await dbGetTopScores(1, 50)
 
-            expect(result).toEqual(mockScores)
-            expect(mockExecute).toHaveBeenCalledWith(
-                expect.stringContaining("ORDER BY ts.score DESC"),
-                [1, 3, 10]
-            )
+            // Should combine and sort by score DESC
+            expect(result).toHaveLength(2)
+            expect(result[0].score).toBe(5000)
+            expect(result[1].score).toBe(4500)
+            expect(mockQuery).toHaveBeenCalledTimes(2)
         })
 
         it("should return empty array when no scores", async () => {
-            mockExecute.mockResolvedValue([[]])
+            mockQuery
+                .mockResolvedValueOnce([[]]) // Android query
+                .mockResolvedValueOnce([[]]) // Human query
 
-            const result = await dbGetTopScores(1, 1, 10)
+            const result = await dbGetTopScores(1, 50)
 
             expect(result).toEqual([])
         })
 
         it("should return empty array on error", async () => {
-            mockExecute.mockRejectedValue(new Error("DB error"))
+            mockQuery.mockRejectedValue(new Error("DB error"))
 
-            const result = await dbGetTopScores(1, 1, 10)
+            const result = await dbGetTopScores(1, 50)
 
             expect(result).toEqual([])
         })
     })
 
-    describe("dbSubmitScore", () => {
-        it("should submit score and return insertId", async () => {
-            mockExecute.mockResolvedValue([{ insertId: 123 }])
+    describe("dbGetTopScoresByType", () => {
+        it("should return top scores filtered by game type", async () => {
+            const mockScores = [
+                { id: 1, score: 5000, user_id: 1, game_type: 3 },
+            ]
+            mockQuery.mockResolvedValue([mockScores])
 
+            const result = await dbGetTopScoresByType(1, 3, 10)
+
+            expect(result).toEqual(mockScores)
+            expect(mockQuery).toHaveBeenCalledWith(
+                expect.stringContaining("game_type = ?"),
+                [1, 3, 1, 3, 10]
+            )
+        })
+    })
+
+    describe("dbScoreExists", () => {
+        it("should return true if score exists", async () => {
+            mockExecute.mockResolvedValue([[{ id: 1 }]])
+
+            const result = await dbScoreExists(1, 5000, 5)
+
+            expect(result).toBe(true)
+        })
+
+        it("should return false if score does not exist", async () => {
+            mockExecute.mockResolvedValue([[]])
+
+            const result = await dbScoreExists(1, 5000, 5)
+
+            expect(result).toBe(false)
+        })
+
+        it("should return true on error (safe default)", async () => {
+            mockExecute.mockRejectedValue(new Error("DB error"))
+
+            const result = await dbScoreExists(1, 5000, 5)
+
+            expect(result).toBe(true)
+        })
+    })
+
+    describe("dbSubmitScore", () => {
+        it("should reject scores below threshold", async () => {
             const result = await dbSubmitScore({
                 userId: 1,
                 opponentId: 2,
-                score: 500,
+                score: 2000, // Below 3000 threshold
                 timeMs: 60000,
                 gameType: 3,
                 gameVariant: 1,
@@ -68,28 +128,180 @@ describe("db/navalclash/leaderboard", () => {
                 opponentRank: 8,
             })
 
-            expect(result).toBe(123)
-            expect(mockExecute).toHaveBeenCalledWith(
-                expect.stringContaining("INSERT INTO topscores"),
-                [1, 2, 500, 60000, 3, 1, 5, 8]
+            expect(result.success).toBe(false)
+            expect(result.reason).toContain("below threshold")
+            expect(mockExecute).not.toHaveBeenCalledWith(
+                expect.stringContaining("INSERT"),
+                expect.anything()
             )
         })
 
-        it("should return null on error", async () => {
-            mockExecute.mockRejectedValue(new Error("FK violation"))
-
+        it("should reject scores with insufficient game time", async () => {
             const result = await dbSubmitScore({
-                userId: 999,
-                opponentId: 999,
-                score: 100,
-                timeMs: 1000,
-                gameType: 1,
+                userId: 1,
+                opponentId: 2,
+                score: 5000,
+                timeMs: 20000, // Below 30000ms minimum
+                gameType: 3,
                 gameVariant: 1,
-                userRank: 1,
-                opponentRank: 1,
+                userRank: 5,
+                opponentRank: 8,
             })
 
+            expect(result.success).toBe(false)
+            expect(result.reason).toContain("below minimum")
+        })
+
+        it("should reject duplicate scores", async () => {
+            // Mock dbScoreExists to return true (duplicate)
+            mockExecute.mockResolvedValueOnce([[{ id: 123 }]])
+
+            const result = await dbSubmitScore({
+                userId: 1,
+                opponentId: 2,
+                score: 5000,
+                timeMs: 60000,
+                gameType: 3,
+                gameVariant: 1,
+                userRank: 5,
+                opponentRank: 8,
+            })
+
+            expect(result.success).toBe(false)
+            expect(result.reason).toBe("Duplicate score")
+        })
+
+        it("should submit valid score and return scoreId", async () => {
+            // Mock dbScoreExists (no duplicate)
+            mockExecute.mockResolvedValueOnce([[]])
+            // Mock INSERT
+            mockExecute.mockResolvedValueOnce([{ insertId: 456 }])
+
+            const result = await dbSubmitScore({
+                userId: 1,
+                opponentId: 2,
+                score: 5000,
+                timeMs: 60000,
+                gameType: 3,
+                gameVariant: 1,
+                userRank: 5,
+                opponentRank: 8,
+            })
+
+            expect(result.success).toBe(true)
+            expect(result.scoreId).toBe(456)
+        })
+
+        it("should return failure on database error", async () => {
+            // Mock dbScoreExists (no duplicate)
+            mockExecute.mockResolvedValueOnce([[]])
+            // Mock INSERT failure
+            mockExecute.mockRejectedValueOnce(new Error("FK violation"))
+
+            const result = await dbSubmitScore({
+                userId: 1,
+                opponentId: 2,
+                score: 5000,
+                timeMs: 60000,
+                gameType: 3,
+                gameVariant: 1,
+                userRank: 5,
+                opponentRank: 8,
+            })
+
+            expect(result.success).toBe(false)
+            expect(result.reason).toContain("FK violation")
+        })
+    })
+
+    describe("dbGetUserBestScore", () => {
+        it("should return user's best score", async () => {
+            mockExecute.mockResolvedValue([[{ best_score: 7500 }]])
+
+            const result = await dbGetUserBestScore(1, 1)
+
+            expect(result).toBe(7500)
+        })
+
+        it("should return 0 if no scores", async () => {
+            mockExecute.mockResolvedValue([[{ best_score: null }]])
+
+            const result = await dbGetUserBestScore(1, 1)
+
+            expect(result).toBe(0)
+        })
+
+        it("should return 0 on error", async () => {
+            mockExecute.mockRejectedValue(new Error("DB error"))
+
+            const result = await dbGetUserBestScore(1, 1)
+
+            expect(result).toBe(0)
+        })
+    })
+
+    describe("dbGetUserLeaderboardRank", () => {
+        it("should return user's rank on leaderboard", async () => {
+            // Mock dbGetUserBestScore
+            mockExecute.mockResolvedValueOnce([[{ best_score: 5000 }]])
+            // Mock count query
+            mockExecute.mockResolvedValueOnce([[{ rank: 4 }]])
+
+            const result = await dbGetUserLeaderboardRank(1, 1)
+
+            expect(result).toBe(5) // 4 users above + 1
+        })
+
+        it("should return null if user has no scores", async () => {
+            mockExecute.mockResolvedValueOnce([[{ best_score: null }]])
+
+            const result = await dbGetUserLeaderboardRank(1, 1)
+
             expect(result).toBeNull()
+        })
+    })
+
+    describe("dbGetTopStars", () => {
+        it("should return top players by stars", async () => {
+            const mockUsers = [
+                { id: 1, name: "StarPlayer1", stars: 5000, rank: 8 },
+                { id: 2, name: "StarPlayer2", stars: 3000, rank: 6 },
+            ]
+            mockQuery.mockResolvedValue([mockUsers])
+
+            const result = await dbGetTopStars(1, 50)
+
+            expect(result).toEqual(mockUsers)
+            expect(mockQuery).toHaveBeenCalledWith(
+                expect.stringContaining("ORDER BY stars DESC"),
+                [1, 50]
+            )
+        })
+
+        it("should return empty array when no users", async () => {
+            mockQuery.mockResolvedValue([[]])
+
+            const result = await dbGetTopStars(1, 50)
+
+            expect(result).toEqual([])
+        })
+
+        it("should return empty array on error", async () => {
+            mockQuery.mockRejectedValue(new Error("DB error"))
+
+            const result = await dbGetTopStars(1, 50)
+
+            expect(result).toEqual([])
+        })
+    })
+
+    describe("constants", () => {
+        it("should export TOPSCORE_THRESHOLD as 3000", () => {
+            expect(TOPSCORE_THRESHOLD).toBe(3000)
+        })
+
+        it("should export MIN_GAME_TIME_MS as 30000", () => {
+            expect(MIN_GAME_TIME_MS).toBe(30000)
         })
     })
 })

--- a/db/navalclash/leaderboard.test.js
+++ b/db/navalclash/leaderboard.test.js
@@ -35,10 +35,24 @@ describe("db/navalclash/leaderboard", () => {
     describe("dbGetTopScores", () => {
         it("should return top scores from both Android and Human categories", async () => {
             const androidScores = [
-                { id: 1, score: 5000, user_id: 1, name: "Player1", game_type: 1, created_at: new Date() },
+                {
+                    id: 1,
+                    score: 5000,
+                    user_id: 1,
+                    name: "Player1",
+                    game_type: 1,
+                    created_at: new Date(),
+                },
             ]
             const humanScores = [
-                { id: 2, score: 4500, user_id: 2, name: "Player2", game_type: 3, created_at: new Date() },
+                {
+                    id: 2,
+                    score: 4500,
+                    user_id: 2,
+                    name: "Player2",
+                    game_type: 3,
+                    created_at: new Date(),
+                },
             ]
             mockQuery
                 .mockResolvedValueOnce([androidScores]) // Android query

--- a/db/navalclash/sessions.js
+++ b/db/navalclash/sessions.js
@@ -182,8 +182,9 @@ async function dbGetConfig(name) {
  * Session finish status codes.
  */
 const SESSION_STATUS = {
-    IN_PROGRESS: 0,
-    FINISHED_OK: 1,
+    WAITING: 0, // Waiting for second player
+    IN_PROGRESS: 1, // Both players connected, game in progress
+    FINISHED_OK: 10, // Game finished normally
     FINISHED_TERMINATED_WAITING: 2,
     FINISHED_SURRENDERED_AUTO: 3,
     FINISHED_SURRENDERED: 4,

--- a/db/navalclash/sessions.js
+++ b/db/navalclash/sessions.js
@@ -73,7 +73,12 @@ function isAgentVersion(version) {
  * @param {Object} conn - Database connection (for transaction)
  * @returns {Promise<Object|null>} Waiting session or null
  */
-async function dbFindWaitingSession(excludeUserId, gameVariant, joinerVersion, conn) {
+async function dbFindWaitingSession(
+    excludeUserId,
+    gameVariant,
+    joinerVersion,
+    conn
+) {
     const db = conn || pool
     const joinerIsAgent = isAgentVersion(joinerVersion)
 
@@ -94,7 +99,12 @@ async function dbFindWaitingSession(excludeUserId, gameVariant, joinerVersion, c
                      ORDER BY gs.created_at ASC
                      LIMIT 1
                      FOR UPDATE`
-            params = [excludeUserId, gameVariant, AGENT_VERSION_MIN, AGENT_VERSION_MAX]
+            params = [
+                excludeUserId,
+                gameVariant,
+                AGENT_VERSION_MIN,
+                AGENT_VERSION_MAX,
+            ]
         } else {
             // Human joining - can match with anyone
             query = `SELECT gs.*, u.name as user_one_name

--- a/db/navalclash/sessions.js
+++ b/db/navalclash/sessions.js
@@ -65,7 +65,9 @@ function isAgentVersion(version) {
 }
 
 /**
- * Finds a waiting session for matchmaking.
+ * Finds a waiting session for random matchmaking.
+ * Excludes personal sessions (target_rival_id IS NOT NULL) to prevent
+ * random players from joining sessions meant for a specific rival.
  * Prevents agent vs agent matchmaking - agents can only play against humans.
  *
  * @param {number} excludeUserId - User ID to exclude from matching
@@ -87,7 +89,7 @@ async function dbFindWaitingSession(
         let query, params
 
         if (joinerIsAgent) {
-            // Agent joining - only match with humans (non-agent versions)
+            // Agent joining - only match with humans, exclude personal sessions
             query = `SELECT gs.*, u.name as user_one_name
                      FROM game_sessions gs
                      JOIN users u ON u.id = gs.user_one_id
@@ -95,6 +97,7 @@ async function dbFindWaitingSession(
                        AND gs.user_two_id IS NULL
                        AND gs.user_one_id != ?
                        AND gs.game_variant = ?
+                       AND gs.target_rival_id IS NULL
                        AND gs.last_seen_one > DATE_SUB(NOW(3), INTERVAL 45 SECOND)
                        AND (gs.version_one < ? OR gs.version_one > ?)
                      ORDER BY gs.created_at ASC
@@ -107,7 +110,7 @@ async function dbFindWaitingSession(
                 AGENT_VERSION_MAX,
             ]
         } else {
-            // Human joining - can match with anyone
+            // Human joining - match with anyone, exclude personal sessions
             query = `SELECT gs.*, u.name as user_one_name
                      FROM game_sessions gs
                      JOIN users u ON u.id = gs.user_one_id
@@ -115,6 +118,7 @@ async function dbFindWaitingSession(
                        AND gs.user_two_id IS NULL
                        AND gs.user_one_id != ?
                        AND gs.game_variant = ?
+                       AND gs.target_rival_id IS NULL
                        AND gs.last_seen_one > DATE_SUB(NOW(3), INTERVAL 45 SECOND)
                      ORDER BY gs.created_at ASC
                      LIMIT 1

--- a/db/navalclash/sessions.js
+++ b/db/navalclash/sessions.js
@@ -38,8 +38,9 @@ async function dbCreateSession(sessionId, userId, version, gameVariant) {
     try {
         await pool.execute(
             `INSERT INTO game_sessions
-                (id, user_one_id, user_one_connected_at, version_one, game_variant, status)
-             VALUES (?, ?, NOW(3), ?, ?, 0)`,
+                (id, user_one_id, user_one_connected_at, version_one,
+                 game_variant, status, last_seen_one)
+             VALUES (?, ?, NOW(3), ?, ?, 0, NOW(3))`,
             [sessionId.toString(), userId, version, gameVariant]
         )
         return true
@@ -94,7 +95,7 @@ async function dbFindWaitingSession(
                        AND gs.user_two_id IS NULL
                        AND gs.user_one_id != ?
                        AND gs.game_variant = ?
-                       AND gs.updated_at > DATE_SUB(NOW(3), INTERVAL 2 MINUTE)
+                       AND gs.last_seen_one > DATE_SUB(NOW(3), INTERVAL 45 SECOND)
                        AND (gs.version_one < ? OR gs.version_one > ?)
                      ORDER BY gs.created_at ASC
                      LIMIT 1
@@ -114,7 +115,7 @@ async function dbFindWaitingSession(
                        AND gs.user_two_id IS NULL
                        AND gs.user_one_id != ?
                        AND gs.game_variant = ?
-                       AND gs.updated_at > DATE_SUB(NOW(3), INTERVAL 2 MINUTE)
+                       AND gs.last_seen_one > DATE_SUB(NOW(3), INTERVAL 45 SECOND)
                      ORDER BY gs.created_at ASC
                      LIMIT 1
                      FOR UPDATE`
@@ -147,6 +148,7 @@ async function dbJoinSession(sessionId, userId, version, conn) {
                 user_two_connected_at = NOW(3),
                 version_two = ?,
                 status = 1,
+                last_seen_two = NOW(3),
                 updated_at = NOW(3)
              WHERE id = ?`,
             [userId, version, sessionId.toString()]
@@ -273,6 +275,116 @@ async function dbTerminateUserSessions(userId, conn) {
     }
 }
 
+/**
+ * Updates the last_seen timestamp for a specific player in a session.
+ * Also updates updated_at via ON UPDATE trigger.
+ *
+ * @param {BigInt|string} baseSessionId - Base session ID (even)
+ * @param {number} player - Player number (0 or 1)
+ * @returns {Promise<boolean>} True if updated successfully
+ */
+async function dbUpdatePlayerLastSeen(baseSessionId, player) {
+    const column = player === 0 ? "last_seen_one" : "last_seen_two"
+    try {
+        await pool.execute(
+            `UPDATE game_sessions SET ${column} = NOW(3)
+             WHERE id = ? AND status <= 1`,
+            [baseSessionId.toString()]
+        )
+        return true
+    } catch (error) {
+        console.error("dbUpdatePlayerLastSeen error:", error)
+        return false
+    }
+}
+
+/**
+ * Checks opponent's last_seen timestamp for dead-opponent detection.
+ * Returns session info including opponent's last_seen and session status.
+ *
+ * @param {BigInt|string} baseSessionId - Base session ID (even)
+ * @param {number} player - Current player number (0 or 1)
+ * @returns {Promise<Object|null>} Session info or null
+ */
+async function dbGetOpponentLastSeen(baseSessionId, player) {
+    const column = player === 0 ? "last_seen_two" : "last_seen_one"
+    try {
+        const [rows] = await pool.execute(
+            `SELECT status, ${column} as opponent_last_seen,
+                    user_one_id, user_two_id
+             FROM game_sessions WHERE id = ?`,
+            [baseSessionId.toString()]
+        )
+        return rows.length > 0 ? rows[0] : null
+    } catch (error) {
+        console.error("dbGetOpponentLastSeen error:", error)
+        return null
+    }
+}
+
+/**
+ * Closes a session with given status atomically.
+ * Only closes if session is still active (status <= 1).
+ *
+ * @param {BigInt|string} baseSessionId - Base session ID (even)
+ * @param {number} status - New finish status code
+ * @returns {Promise<number>} Number of affected rows (0 or 1)
+ */
+async function dbCloseStaleSession(baseSessionId, status) {
+    try {
+        const [result] = await pool.execute(
+            `UPDATE game_sessions SET
+                status = ?,
+                finished_at = NOW(3)
+             WHERE id = ? AND status <= 1`,
+            [status, baseSessionId.toString()]
+        )
+        return result.affectedRows
+    } catch (error) {
+        console.error("dbCloseStaleSession error:", error)
+        return 0
+    }
+}
+
+/**
+ * Finds stale sessions that should be purged by the background job.
+ * Returns waiting sessions where player one is stale,
+ * and in-progress sessions where both players are stale.
+ *
+ * @param {number} purgeThresholdSec - Seconds of inactivity before purge (e.g. 120)
+ * @returns {Promise<Array>} Array of stale sessions with id and status
+ */
+async function dbFindStaleSessions(purgeThresholdSec) {
+    try {
+        const [rows] = await pool.execute(
+            `SELECT id, status, user_one_id, user_two_id,
+                    last_seen_one, last_seen_two
+             FROM game_sessions
+             WHERE status <= 1
+               AND (
+                   (status = 0 AND (
+                       last_seen_one IS NULL
+                       OR last_seen_one < DATE_SUB(NOW(3), INTERVAL ? SECOND)
+                   ))
+                   OR
+                   (status = 1 AND (
+                       last_seen_one IS NULL
+                       OR last_seen_one < DATE_SUB(NOW(3), INTERVAL ? SECOND)
+                   ) AND (
+                       last_seen_two IS NULL
+                       OR last_seen_two < DATE_SUB(NOW(3), INTERVAL ? SECOND)
+                   ))
+               )
+             LIMIT 100`,
+            [purgeThresholdSec, purgeThresholdSec, purgeThresholdSec]
+        )
+        return rows
+    } catch (error) {
+        console.error("dbFindStaleSessions error:", error)
+        return []
+    }
+}
+
 module.exports = {
     SESSION_STATUS,
     dbFindSessionById,
@@ -283,4 +395,8 @@ module.exports = {
     dbIncrementMoves,
     dbGetConfig,
     dbTerminateUserSessions,
+    dbUpdatePlayerLastSeen,
+    dbGetOpponentLastSeen,
+    dbCloseStaleSession,
+    dbFindStaleSessions,
 }

--- a/db/navalclash/sessions.test.js
+++ b/db/navalclash/sessions.test.js
@@ -210,8 +210,9 @@ describe("db/navalclash/sessions", () => {
 
     describe("SESSION_STATUS", () => {
         it("should export session status constants", () => {
-            expect(SESSION_STATUS.IN_PROGRESS).toBe(0)
-            expect(SESSION_STATUS.FINISHED_OK).toBe(1)
+            expect(SESSION_STATUS.WAITING).toBe(0)
+            expect(SESSION_STATUS.IN_PROGRESS).toBe(1)
+            expect(SESSION_STATUS.FINISHED_OK).toBe(10)
             expect(SESSION_STATUS.FINISHED_TERMINATED_DUPLICATE).toBe(7)
         })
     })

--- a/db/navalclash/sessions.test.js
+++ b/db/navalclash/sessions.test.js
@@ -22,6 +22,10 @@ const {
     dbIncrementMoves,
     dbGetConfig,
     dbTerminateUserSessions,
+    dbUpdatePlayerLastSeen,
+    dbGetOpponentLastSeen,
+    dbCloseStaleSession,
+    dbFindStaleSessions,
 } = require("./sessions")
 
 describe("db/navalclash/sessions", () => {
@@ -63,7 +67,7 @@ describe("db/navalclash/sessions", () => {
     })
 
     describe("dbCreateSession", () => {
-        it("should create session", async () => {
+        it("should create session with last_seen_one", async () => {
             mockExecute.mockResolvedValue([{ affectedRows: 1 }])
 
             const result = await dbCreateSession(100000n, 1, 150, 1)
@@ -72,6 +76,10 @@ describe("db/navalclash/sessions", () => {
             expect(mockExecute).toHaveBeenCalledWith(
                 expect.stringContaining("INSERT INTO game_sessions"),
                 ["100000", 1, 150, 1]
+            )
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("last_seen_one"),
+                expect.any(Array)
             )
         })
 
@@ -85,7 +93,7 @@ describe("db/navalclash/sessions", () => {
     })
 
     describe("dbFindWaitingSession", () => {
-        it("should find waiting session for human joiner", async () => {
+        it("should find waiting session using last_seen_one filter", async () => {
             const mockSession = { id: 1000n, user_one_id: 5, status: 0 }
             mockExecute.mockResolvedValue([[mockSession]])
 
@@ -93,9 +101,18 @@ describe("db/navalclash/sessions", () => {
 
             expect(result).toEqual(mockSession)
             expect(mockExecute).toHaveBeenCalledWith(
-                expect.stringContaining("WHERE gs.status = 0"),
+                expect.stringContaining("last_seen_one > DATE_SUB"),
                 [10, 1]
             )
+        })
+
+        it("should not use updated_at for staleness check", async () => {
+            mockExecute.mockResolvedValue([[]])
+
+            await dbFindWaitingSession(10, 1, 100, null)
+
+            const query = mockExecute.mock.calls[0][0]
+            expect(query).not.toContain("updated_at > DATE_SUB")
         })
 
         it("should return null when no waiting session", async () => {
@@ -144,7 +161,7 @@ describe("db/navalclash/sessions", () => {
     })
 
     describe("dbJoinSession", () => {
-        it("should join session as player two", async () => {
+        it("should join session with last_seen_two", async () => {
             mockExecute.mockResolvedValue([{ affectedRows: 1 }])
 
             const result = await dbJoinSession(12345n, 2, 150)
@@ -153,6 +170,10 @@ describe("db/navalclash/sessions", () => {
             expect(mockExecute).toHaveBeenCalledWith(
                 expect.stringContaining("user_two_id = ?"),
                 [2, 150, "12345"]
+            )
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("last_seen_two"),
+                expect.any(Array)
             )
         })
 
@@ -282,6 +303,180 @@ describe("db/navalclash/sessions", () => {
             const result = await dbTerminateUserSessions(1)
 
             expect(result).toBe(0)
+        })
+    })
+
+    describe("dbUpdatePlayerLastSeen", () => {
+        it("should update last_seen_one for player 0", async () => {
+            mockExecute.mockResolvedValue([{ affectedRows: 1 }])
+
+            const result = await dbUpdatePlayerLastSeen(1000n, 0)
+
+            expect(result).toBe(true)
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("last_seen_one = NOW(3)"),
+                ["1000"]
+            )
+        })
+
+        it("should update last_seen_two for player 1", async () => {
+            mockExecute.mockResolvedValue([{ affectedRows: 1 }])
+
+            const result = await dbUpdatePlayerLastSeen(1000n, 1)
+
+            expect(result).toBe(true)
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("last_seen_two = NOW(3)"),
+                ["1000"]
+            )
+        })
+
+        it("should only update active sessions", async () => {
+            mockExecute.mockResolvedValue([{ affectedRows: 0 }])
+
+            await dbUpdatePlayerLastSeen(1000n, 0)
+
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("status <= 1"),
+                expect.any(Array)
+            )
+        })
+
+        it("should return false on error", async () => {
+            mockExecute.mockRejectedValue(new Error("DB error"))
+
+            const result = await dbUpdatePlayerLastSeen(1000n, 0)
+
+            expect(result).toBe(false)
+        })
+    })
+
+    describe("dbGetOpponentLastSeen", () => {
+        it("should get last_seen_two when player is 0", async () => {
+            mockExecute.mockResolvedValue([
+                [
+                    {
+                        status: 1,
+                        opponent_last_seen: new Date(),
+                        user_one_id: 1,
+                        user_two_id: 2,
+                    },
+                ],
+            ])
+
+            const result = await dbGetOpponentLastSeen(1000n, 0)
+
+            expect(result).toBeTruthy()
+            expect(result.status).toBe(1)
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("last_seen_two as opponent_last_seen"),
+                ["1000"]
+            )
+        })
+
+        it("should get last_seen_one when player is 1", async () => {
+            mockExecute.mockResolvedValue([
+                [
+                    {
+                        status: 1,
+                        opponent_last_seen: new Date(),
+                        user_one_id: 1,
+                        user_two_id: 2,
+                    },
+                ],
+            ])
+
+            const result = await dbGetOpponentLastSeen(1000n, 1)
+
+            expect(result).toBeTruthy()
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("last_seen_one as opponent_last_seen"),
+                ["1000"]
+            )
+        })
+
+        it("should return null when session not found", async () => {
+            mockExecute.mockResolvedValue([[]])
+
+            const result = await dbGetOpponentLastSeen(9999n, 0)
+
+            expect(result).toBeNull()
+        })
+
+        it("should return null on error", async () => {
+            mockExecute.mockRejectedValue(new Error("DB error"))
+
+            const result = await dbGetOpponentLastSeen(1000n, 0)
+
+            expect(result).toBeNull()
+        })
+    })
+
+    describe("dbCloseStaleSession", () => {
+        it("should close active session with given status", async () => {
+            mockExecute.mockResolvedValue([{ affectedRows: 1 }])
+
+            const result = await dbCloseStaleSession(1000n, 9)
+
+            expect(result).toBe(1)
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("status = ?"),
+                [9, "1000"]
+            )
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("AND status <= 1"),
+                expect.any(Array)
+            )
+        })
+
+        it("should return 0 when session already closed", async () => {
+            mockExecute.mockResolvedValue([{ affectedRows: 0 }])
+
+            const result = await dbCloseStaleSession(1000n, 9)
+
+            expect(result).toBe(0)
+        })
+
+        it("should return 0 on error", async () => {
+            mockExecute.mockRejectedValue(new Error("DB error"))
+
+            const result = await dbCloseStaleSession(1000n, 9)
+
+            expect(result).toBe(0)
+        })
+    })
+
+    describe("dbFindStaleSessions", () => {
+        it("should find stale sessions", async () => {
+            const staleSessions = [
+                { id: "1000", status: 0, last_seen_one: null },
+                { id: "2000", status: 1, last_seen_one: null },
+            ]
+            mockExecute.mockResolvedValue([staleSessions])
+
+            const result = await dbFindStaleSessions(120)
+
+            expect(result).toHaveLength(2)
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("status <= 1"),
+                [120, 120, 120]
+            )
+        })
+
+        it("should return empty array on error", async () => {
+            mockExecute.mockRejectedValue(new Error("DB error"))
+
+            const result = await dbFindStaleSessions(120)
+
+            expect(result).toEqual([])
+        })
+
+        it("should return empty array when no stale sessions", async () => {
+            mockExecute.mockResolvedValue([[]])
+
+            const result = await dbFindStaleSessions(120)
+
+            expect(result).toEqual([])
         })
     })
 })

--- a/db/navalclash/training.js
+++ b/db/navalclash/training.js
@@ -53,7 +53,12 @@ async function dbLogTrainingShot(data, ctx) {
             ]
         )
         logger.debug(
-            { ...ctx, shotNum: data.shotNumber, x: data.targetX, y: data.targetY },
+            {
+                ...ctx,
+                shotNum: data.shotNumber,
+                x: data.targetX,
+                y: data.targetY,
+            },
             "Training shot logged"
         )
         return true
@@ -245,7 +250,10 @@ async function dbFinalizeTrainingGame(gameId, ctx) {
                     fieldJsonSample:
                         typeof field.field_json === "string"
                             ? field.field_json.substring(0, 500)
-                            : JSON.stringify(field.field_json).substring(0, 500),
+                            : JSON.stringify(field.field_json).substring(
+                                  0,
+                                  500
+                              ),
                 },
                 "Processing field data for player"
             )
@@ -275,7 +283,10 @@ async function dbFinalizeTrainingGame(gameId, ctx) {
         }
 
         if (!playerOneShips || !playerTwoShips) {
-            logger.warn(ctx, "Could not extract ships from field data, skipping")
+            logger.warn(
+                ctx,
+                "Could not extract ships from field data, skipping"
+            )
             return false
         }
 

--- a/db/navalclash/users.js
+++ b/db/navalclash/users.js
@@ -314,7 +314,9 @@ async function dbLogProfileAction(userId, action, details) {
         return true
     } catch (error) {
         // Log table might not exist, just log to console
-        console.log(`Profile action: user=${userId} action=${action} ${details}`)
+        console.log(
+            `Profile action: user=${userId} action=${action} ${details}`
+        )
         return false
     }
 }
@@ -356,7 +358,11 @@ async function dbUpdateUserLastDevice(userId, deviceId) {
  * @returns {Promise<boolean>} True if updated successfully
  */
 async function dbUpdateLocalStats(conn, userId, clientUser) {
-    if (!clientUser || !Array.isArray(clientUser.ga) || !Array.isArray(clientUser.wa)) {
+    if (
+        !clientUser ||
+        !Array.isArray(clientUser.ga) ||
+        !Array.isArray(clientUser.wa)
+    ) {
         return false
     }
 
@@ -421,8 +427,7 @@ async function dbUpdateLocalStats(conn, userId, clientUser) {
  * @returns {Promise<boolean>} True if updated successfully
  */
 async function dbUpdateProfileAndStats(db, userId, userData) {
-    const hasStats =
-        Array.isArray(userData.ga) && Array.isArray(userData.wa)
+    const hasStats = Array.isArray(userData.ga) && Array.isArray(userData.wa)
 
     try {
         if (hasStats) {

--- a/db/navalclash/users.js
+++ b/db/navalclash/users.js
@@ -13,9 +13,9 @@ const { pool } = require("./pool")
  * @param {string} name - Player name
  * @returns {Promise<Object|null>} User object or null if not found
  */
-async function dbFindUserByUuidAndName(uuid, name) {
+async function dbFindUserByUuidAndName(uuid, name, db) {
     try {
-        const [rows] = await pool.execute(
+        const [rows] = await (db || pool).execute(
             "SELECT * FROM users WHERE uuid = ? AND name = ?",
             [uuid, name]
         )
@@ -196,7 +196,7 @@ async function dbUpdateUserProfile(conn, userId, userData) {
             `UPDATE users SET
                 face = COALESCE(?, face),
                 lang = COALESCE(?, lang),
-                tz = COALESCE(?, tz),
+                timezone = COALESCE(?, timezone),
                 coins = COALESCE(?, coins),
                 updated_at = NOW()
              WHERE id = ?`,
@@ -236,7 +236,7 @@ async function dbSyncUserProfile(userId, clientUser, version) {
             `UPDATE users SET
                 face = COALESCE(?, face),
                 lang = COALESCE(?, lang),
-                tz = COALESCE(?, tz),
+                timezone = COALESCE(?, timezone),
                 version = ?,
                 updated_at = NOW()
              WHERE id = ?`,
@@ -409,6 +409,95 @@ async function dbUpdateLocalStats(conn, userId, clientUser) {
     }
 }
 
+/**
+ * Updates user profile fields and local game stats in a single query.
+ * Combines profile update (face, lang, timezone, rank, stars) with
+ * local stats update (android, bluetooth, passplay games/wins).
+ * Coins are server-authoritative and never updated from client data.
+ *
+ * @param {Object} db - Database connection or pool
+ * @param {number} userId - User ID
+ * @param {Object} userData - Client's PlayerInfo object
+ * @returns {Promise<boolean>} True if updated successfully
+ */
+async function dbUpdateProfileAndStats(db, userId, userData) {
+    const hasStats =
+        Array.isArray(userData.ga) && Array.isArray(userData.wa)
+
+    try {
+        if (hasStats) {
+            const gamesAndroid = userData.ga[0] || 0
+            const gamesBluetooth = userData.ga[1] || 0
+            const gamesPassplay = userData.ga[3] || 0
+            const winsAndroid = userData.wa[0] || 0
+            const winsBluetooth = userData.wa[1] || 0
+            const winsPassplay = userData.wa[3] || 0
+
+            await db.execute(
+                `UPDATE users SET
+                    face = COALESCE(?, face),
+                    lang = COALESCE(?, lang),
+                    timezone = COALESCE(?, timezone),
+                    \`rank\` = COALESCE(?, \`rank\`),
+                    stars = COALESCE(?, stars),
+                    games_android = ?,
+                    games_bluetooth = ?,
+                    games_passplay = ?,
+                    wins_android = ?,
+                    wins_bluetooth = ?,
+                    wins_passplay = ?,
+                    games = ? + ? + games_web + ?,
+                    gameswon = ? + ? + wins_web + ?,
+                    updated_at = NOW()
+                 WHERE id = ?`,
+                [
+                    userData.fc ?? null,
+                    userData.l ?? null,
+                    userData.tz ?? null,
+                    userData.rk ?? null,
+                    userData.st ?? null,
+                    gamesAndroid,
+                    gamesBluetooth,
+                    gamesPassplay,
+                    winsAndroid,
+                    winsBluetooth,
+                    winsPassplay,
+                    gamesAndroid,
+                    gamesBluetooth,
+                    gamesPassplay,
+                    winsAndroid,
+                    winsBluetooth,
+                    winsPassplay,
+                    userId,
+                ]
+            )
+        } else {
+            await db.execute(
+                `UPDATE users SET
+                    face = COALESCE(?, face),
+                    lang = COALESCE(?, lang),
+                    timezone = COALESCE(?, timezone),
+                    \`rank\` = COALESCE(?, \`rank\`),
+                    stars = COALESCE(?, stars),
+                    updated_at = NOW()
+                 WHERE id = ?`,
+                [
+                    userData.fc ?? null,
+                    userData.l ?? null,
+                    userData.tz ?? null,
+                    userData.rk ?? null,
+                    userData.st ?? null,
+                    userId,
+                ]
+            )
+        }
+        return true
+    } catch (error) {
+        console.error("dbUpdateProfileAndStats error:", error)
+        return false
+    }
+}
+
 module.exports = {
     dbFindUserByUuidAndName,
     dbFindUserById,
@@ -423,4 +512,5 @@ module.exports = {
     dbLogProfileAction,
     dbUpdateUserLastDevice,
     dbUpdateLocalStats,
+    dbUpdateProfileAndStats,
 }

--- a/db/navalclash/users.js
+++ b/db/navalclash/users.js
@@ -378,9 +378,16 @@ async function dbUpdateLocalStats(conn, userId, clientUser) {
     const winsBluetooth = wa[1] || 0
     const winsPassplay = wa[3] || 0
 
+    // Stars are accumulated by the client across all game modes.
+    // Server only awards stars for web games, so the client's total
+    // is always the most up-to-date value. We take the max of client
+    // and server to avoid losing stars from either source.
+    const clientStars = clientUser.st || 0
+
     try {
-        // Update non-web stats and recalculate totals
+        // Update non-web stats, stars, and recalculate totals
         // Total = android + bluetooth + web (from server) + passplay
+        // Stars = max(client, server) to never lose stars from either side
         await db.execute(
             `UPDATE users SET
                 games_android = ?,
@@ -389,6 +396,7 @@ async function dbUpdateLocalStats(conn, userId, clientUser) {
                 wins_android = ?,
                 wins_bluetooth = ?,
                 wins_passplay = ?,
+                stars = GREATEST(stars, ?),
                 games = ? + ? + games_web + ?,
                 gameswon = ? + ? + wins_web + ?
              WHERE id = ?`,
@@ -399,6 +407,7 @@ async function dbUpdateLocalStats(conn, userId, clientUser) {
                 winsAndroid,
                 winsBluetooth,
                 winsPassplay,
+                clientStars,
                 gamesAndroid,
                 gamesBluetooth,
                 gamesPassplay,

--- a/db/navalclash/users.test.js
+++ b/db/navalclash/users.test.js
@@ -204,20 +204,21 @@ describe("db/navalclash/users", () => {
     })
 
     describe("dbUpdateLocalStats", () => {
-        it("should update local stats from client data", async () => {
+        it("should update local stats and stars from client data", async () => {
             mockExecute.mockResolvedValue([{ affectedRows: 1 }])
 
             const clientUser = {
                 ga: [10, 5, 20, 3], // android, bt, web, passplay
                 wa: [8, 3, 15, 2],
+                st: 450, // stars
             }
 
             const result = await dbUpdateLocalStats(null, 1, clientUser)
 
             expect(result).toBe(true)
             expect(mockExecute).toHaveBeenCalledWith(
-                expect.stringContaining("games_android = ?"),
-                [10, 5, 3, 8, 3, 2, 10, 5, 3, 8, 3, 2, 1]
+                expect.stringContaining("stars = GREATEST(stars, ?)"),
+                [10, 5, 3, 8, 3, 2, 450, 10, 5, 3, 8, 3, 2, 1]
             )
         })
 
@@ -276,21 +277,22 @@ describe("db/navalclash/users", () => {
             expect(result).toBe(false)
         })
 
-        it("should handle missing array indices with defaults", async () => {
+        it("should handle missing array indices and stars with defaults", async () => {
             mockExecute.mockResolvedValue([{ affectedRows: 1 }])
 
             const clientUser = {
                 ga: [10], // only android
                 wa: [8, 3], // android, bt
+                // st not provided - should default to 0
             }
 
             const result = await dbUpdateLocalStats(null, 1, clientUser)
 
             expect(result).toBe(true)
-            // Missing indices should default to 0
+            // Missing indices should default to 0, stars defaults to 0
             expect(mockExecute).toHaveBeenCalledWith(
                 expect.any(String),
-                [10, 0, 0, 8, 3, 0, 10, 0, 0, 8, 3, 0, 1]
+                [10, 0, 0, 8, 3, 0, 0, 10, 0, 0, 8, 3, 0, 1]
             )
         })
     })

--- a/db/navalclash/weapons.js
+++ b/db/navalclash/weapons.js
@@ -1,0 +1,205 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ */
+
+const { pool } = require("./pool")
+
+/**
+ * Gets user's weapon inventory.
+ *
+ * @param {number} userId - User ID
+ * @returns {Promise<Object>} Map of weaponId -> quantity
+ */
+async function dbGetUserWeaponInventory(userId) {
+    try {
+        const [rows] = await pool.execute(
+            `SELECT item_id, quantity FROM user_inventory
+             WHERE user_id = ? AND item_type = 'weapon'`,
+            [userId]
+        )
+        const inventory = {}
+        for (const row of rows) {
+            inventory[row.item_id] = row.quantity
+        }
+        return inventory
+    } catch (error) {
+        console.error("dbGetUserWeaponInventory error:", error)
+        return {}
+    }
+}
+
+/**
+ * Gets tracked weapons for a session player.
+ *
+ * @param {BigInt|string} sessionId - Base session ID
+ * @param {number} player - Player number (0 or 1)
+ * @returns {Promise<Object|null>} Tracked weapons JSON or null
+ */
+async function dbGetTrackedWeapons(sessionId, player) {
+    try {
+        const column =
+            player === 0 ? "weapons_tracked_one" : "weapons_tracked_two"
+        const [rows] = await pool.execute(
+            `SELECT ${column} as tracked FROM game_sessions WHERE id = ?`,
+            [sessionId.toString()]
+        )
+        if (rows.length === 0) {
+            return null
+        }
+        return rows[0].tracked || {}
+    } catch (error) {
+        console.error("dbGetTrackedWeapons error:", error)
+        return null
+    }
+}
+
+/**
+ * Sets tracked weapons for a session player.
+ *
+ * @param {BigInt|string} sessionId - Base session ID
+ * @param {number} player - Player number (0 or 1)
+ * @param {Object} weapons - Weapon counts { weaponId: count }
+ * @param {Object} conn - Database connection (optional)
+ * @returns {Promise<boolean>} True if successful
+ */
+async function dbSetTrackedWeapons(sessionId, player, weapons, conn) {
+    const db = conn || pool
+    try {
+        const column =
+            player === 0 ? "weapons_tracked_one" : "weapons_tracked_two"
+        await db.execute(
+            `UPDATE game_sessions SET ${column} = ? WHERE id = ?`,
+            [JSON.stringify(weapons), sessionId.toString()]
+        )
+        return true
+    } catch (error) {
+        console.error("dbSetTrackedWeapons error:", error)
+        return false
+    }
+}
+
+/**
+ * Gets weapon usage tracking for a session player.
+ *
+ * @param {BigInt|string} sessionId - Base session ID
+ * @param {number} player - Player number (0 or 1)
+ * @returns {Promise<Object>} Usage tracking { radar: N, shuffle: N }
+ */
+async function dbGetWeaponUsage(sessionId, player) {
+    try {
+        const column = player === 0 ? "weapons_used_one" : "weapons_used_two"
+        const [rows] = await pool.execute(
+            `SELECT ${column} as used FROM game_sessions WHERE id = ?`,
+            [sessionId.toString()]
+        )
+        if (rows.length === 0) {
+            return { radar: 0, shuffle: 0 }
+        }
+        return rows[0].used || { radar: 0, shuffle: 0 }
+    } catch (error) {
+        console.error("dbGetWeaponUsage error:", error)
+        return { radar: 0, shuffle: 0 }
+    }
+}
+
+/**
+ * Increments weapon usage counter for a session player.
+ *
+ * @param {BigInt|string} sessionId - Base session ID
+ * @param {number} player - Player number (0 or 1)
+ * @param {string} weaponType - Weapon type ('radar' or 'shuffle')
+ * @returns {Promise<boolean>} True if successful
+ */
+async function dbIncrementWeaponUsage(sessionId, player, weaponType) {
+    try {
+        const column = player === 0 ? "weapons_used_one" : "weapons_used_two"
+        // Use JSON_SET to increment the counter, defaulting to 1 if not present
+        await pool.execute(
+            `UPDATE game_sessions
+             SET ${column} = JSON_SET(
+                 COALESCE(${column}, '{}'),
+                 '$.${weaponType}',
+                 COALESCE(JSON_EXTRACT(${column}, '$.${weaponType}'), 0) + 1
+             )
+             WHERE id = ?`,
+            [sessionId.toString()]
+        )
+        return true
+    } catch (error) {
+        console.error("dbIncrementWeaponUsage error:", error)
+        return false
+    }
+}
+
+/**
+ * Consumes weapons from user's inventory.
+ * Called at game end for the loser.
+ *
+ * @param {number} userId - User ID
+ * @param {Object} weaponCounts - Map of weaponId -> count to consume
+ * @param {Object} conn - Database connection (required, for transaction)
+ * @returns {Promise<boolean>} True if successful
+ */
+async function dbConsumeWeapons(userId, weaponCounts, conn) {
+    try {
+        for (const [weaponId, count] of Object.entries(weaponCounts)) {
+            if (count <= 0) continue
+
+            // Decrement quantity, delete row if quantity reaches 0
+            await conn.execute(
+                `UPDATE user_inventory
+                 SET quantity = GREATEST(0, quantity - ?)
+                 WHERE user_id = ? AND item_type = 'weapon' AND item_id = ?`,
+                [count, userId, weaponId]
+            )
+        }
+
+        // Clean up zero-quantity rows
+        await conn.execute(
+            `DELETE FROM user_inventory
+             WHERE user_id = ? AND item_type = 'weapon' AND quantity <= 0`,
+            [userId]
+        )
+
+        return true
+    } catch (error) {
+        console.error("dbConsumeWeapons error:", error)
+        return false
+    }
+}
+
+/**
+ * Gets the user ID for a player in a session.
+ *
+ * @param {BigInt|string} sessionId - Base session ID
+ * @param {number} player - Player number (0 or 1)
+ * @returns {Promise<number|null>} User ID or null
+ */
+async function dbGetSessionUserId(sessionId, player) {
+    try {
+        const column = player === 0 ? "user_one_id" : "user_two_id"
+        const [rows] = await pool.execute(
+            `SELECT ${column} as user_id FROM game_sessions WHERE id = ?`,
+            [sessionId.toString()]
+        )
+        if (rows.length === 0) {
+            return null
+        }
+        return rows[0].user_id
+    } catch (error) {
+        console.error("dbGetSessionUserId error:", error)
+        return null
+    }
+}
+
+module.exports = {
+    dbGetUserWeaponInventory,
+    dbGetTrackedWeapons,
+    dbSetTrackedWeapons,
+    dbGetWeaponUsage,
+    dbIncrementWeaponUsage,
+    dbConsumeWeapons,
+    dbGetSessionUserId,
+}

--- a/db/navalclash/weapons.js
+++ b/db/navalclash/weapons.js
@@ -194,6 +194,38 @@ async function dbGetSessionUserId(sessionId, player) {
     }
 }
 
+/**
+ * Gets user's weapon inventory as arrays for client serialization.
+ * Returns weapon quantities and usage counts indexed by weapon type.
+ * Indices: 0=mine, 1=dutch, 2=radar, 3=shuffle, 4=stealth, 5=cshield
+ *
+ * @param {number} userId - User ID
+ * @returns {Promise<{we: number[], wu: number[]}>} Weapon arrays
+ */
+async function dbGetUserWeaponArrays(userId) {
+    const we = [0, 0, 0, 0, 0, 0]
+    const wu = [0, 0, 0, 0, 0, 0]
+
+    try {
+        const [rows] = await pool.execute(
+            `SELECT item_id, quantity, times_used FROM user_inventory
+             WHERE user_id = ? AND item_type = 'weapon'`,
+            [userId]
+        )
+        for (const row of rows) {
+            const idx = parseInt(row.item_id, 10)
+            if (idx >= 0 && idx < 6) {
+                we[idx] = row.quantity || 0
+                wu[idx] = row.times_used || 0
+            }
+        }
+    } catch (error) {
+        console.error("dbGetUserWeaponArrays error:", error)
+    }
+
+    return { we, wu }
+}
+
 module.exports = {
     dbGetUserWeaponInventory,
     dbGetTrackedWeapons,
@@ -202,4 +234,5 @@ module.exports = {
     dbIncrementWeaponUsage,
     dbConsumeWeapons,
     dbGetSessionUserId,
+    dbGetUserWeaponArrays,
 }

--- a/db/navalclash/weapons.test.js
+++ b/db/navalclash/weapons.test.js
@@ -1,0 +1,341 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ */
+
+const mockExecute = jest.fn()
+
+jest.mock("./pool", () => ({
+    pool: {
+        execute: mockExecute,
+    },
+}))
+
+const {
+    dbGetUserWeaponInventory,
+    dbGetTrackedWeapons,
+    dbSetTrackedWeapons,
+    dbGetWeaponUsage,
+    dbIncrementWeaponUsage,
+    dbConsumeWeapons,
+    dbGetSessionUserId,
+} = require("./weapons")
+
+describe("db/navalclash/weapons", () => {
+    beforeEach(() => {
+        mockExecute.mockReset()
+    })
+
+    describe("dbGetUserWeaponInventory", () => {
+        it("should return weapon inventory as map", async () => {
+            mockExecute.mockResolvedValue([
+                [
+                    { item_id: "0", quantity: 5 },
+                    { item_id: "2", quantity: 3 },
+                ],
+            ])
+
+            const result = await dbGetUserWeaponInventory(1)
+
+            expect(result).toEqual({ "0": 5, "2": 3 })
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("SELECT item_id, quantity"),
+                [1]
+            )
+        })
+
+        it("should return empty object when no inventory", async () => {
+            mockExecute.mockResolvedValue([[]])
+
+            const result = await dbGetUserWeaponInventory(1)
+
+            expect(result).toEqual({})
+        })
+
+        it("should return empty object on error", async () => {
+            mockExecute.mockRejectedValue(new Error("DB error"))
+
+            const result = await dbGetUserWeaponInventory(1)
+
+            expect(result).toEqual({})
+        })
+    })
+
+    describe("dbGetTrackedWeapons", () => {
+        it("should return tracked weapons for player 0", async () => {
+            const tracked = { "0": 2, "1": 1 }
+            mockExecute.mockResolvedValue([[{ tracked }]])
+
+            const result = await dbGetTrackedWeapons("1000", 0)
+
+            expect(result).toEqual(tracked)
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("weapons_tracked_one"),
+                ["1000"]
+            )
+        })
+
+        it("should return tracked weapons for player 1", async () => {
+            const tracked = { "2": 3 }
+            mockExecute.mockResolvedValue([[{ tracked }]])
+
+            const result = await dbGetTrackedWeapons("1000", 1)
+
+            expect(result).toEqual(tracked)
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("weapons_tracked_two"),
+                ["1000"]
+            )
+        })
+
+        it("should return empty object when no tracked weapons", async () => {
+            mockExecute.mockResolvedValue([[{ tracked: null }]])
+
+            const result = await dbGetTrackedWeapons("1000", 0)
+
+            expect(result).toEqual({})
+        })
+
+        it("should return null when session not found", async () => {
+            mockExecute.mockResolvedValue([[]])
+
+            const result = await dbGetTrackedWeapons("9999", 0)
+
+            expect(result).toBeNull()
+        })
+
+        it("should return null on error", async () => {
+            mockExecute.mockRejectedValue(new Error("DB error"))
+
+            const result = await dbGetTrackedWeapons("1000", 0)
+
+            expect(result).toBeNull()
+        })
+    })
+
+    describe("dbSetTrackedWeapons", () => {
+        it("should set tracked weapons for player 0", async () => {
+            mockExecute.mockResolvedValue([{ affectedRows: 1 }])
+
+            const weapons = { "0": 2, "2": 1 }
+            const result = await dbSetTrackedWeapons("1000", 0, weapons)
+
+            expect(result).toBe(true)
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("weapons_tracked_one"),
+                [JSON.stringify(weapons), "1000"]
+            )
+        })
+
+        it("should set tracked weapons for player 1", async () => {
+            mockExecute.mockResolvedValue([{ affectedRows: 1 }])
+
+            const weapons = { "1": 1 }
+            const result = await dbSetTrackedWeapons("1000", 1, weapons)
+
+            expect(result).toBe(true)
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("weapons_tracked_two"),
+                [JSON.stringify(weapons), "1000"]
+            )
+        })
+
+        it("should return false on error", async () => {
+            mockExecute.mockRejectedValue(new Error("DB error"))
+
+            const result = await dbSetTrackedWeapons("1000", 0, {})
+
+            expect(result).toBe(false)
+        })
+    })
+
+    describe("dbGetWeaponUsage", () => {
+        it("should return weapon usage for player 0", async () => {
+            const used = { radar: 2, shuffle: 1 }
+            mockExecute.mockResolvedValue([[{ used }]])
+
+            const result = await dbGetWeaponUsage("1000", 0)
+
+            expect(result).toEqual(used)
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("weapons_used_one"),
+                ["1000"]
+            )
+        })
+
+        it("should return weapon usage for player 1", async () => {
+            const used = { radar: 0, shuffle: 3 }
+            mockExecute.mockResolvedValue([[{ used }]])
+
+            const result = await dbGetWeaponUsage("1000", 1)
+
+            expect(result).toEqual(used)
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("weapons_used_two"),
+                ["1000"]
+            )
+        })
+
+        it("should return default usage when null", async () => {
+            mockExecute.mockResolvedValue([[{ used: null }]])
+
+            const result = await dbGetWeaponUsage("1000", 0)
+
+            expect(result).toEqual({ radar: 0, shuffle: 0 })
+        })
+
+        it("should return default usage when session not found", async () => {
+            mockExecute.mockResolvedValue([[]])
+
+            const result = await dbGetWeaponUsage("9999", 0)
+
+            expect(result).toEqual({ radar: 0, shuffle: 0 })
+        })
+
+        it("should return default usage on error", async () => {
+            mockExecute.mockRejectedValue(new Error("DB error"))
+
+            const result = await dbGetWeaponUsage("1000", 0)
+
+            expect(result).toEqual({ radar: 0, shuffle: 0 })
+        })
+    })
+
+    describe("dbIncrementWeaponUsage", () => {
+        it("should increment radar usage for player 0", async () => {
+            mockExecute.mockResolvedValue([{ affectedRows: 1 }])
+
+            const result = await dbIncrementWeaponUsage("1000", 0, "radar")
+
+            expect(result).toBe(true)
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("weapons_used_one"),
+                ["1000"]
+            )
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("$.radar"),
+                ["1000"]
+            )
+        })
+
+        it("should increment shuffle usage for player 1", async () => {
+            mockExecute.mockResolvedValue([{ affectedRows: 1 }])
+
+            const result = await dbIncrementWeaponUsage("1000", 1, "shuffle")
+
+            expect(result).toBe(true)
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("weapons_used_two"),
+                ["1000"]
+            )
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("$.shuffle"),
+                ["1000"]
+            )
+        })
+
+        it("should return false on error", async () => {
+            mockExecute.mockRejectedValue(new Error("DB error"))
+
+            const result = await dbIncrementWeaponUsage("1000", 0, "radar")
+
+            expect(result).toBe(false)
+        })
+    })
+
+    describe("dbConsumeWeapons", () => {
+        const mockConn = {
+            execute: jest.fn(),
+        }
+
+        beforeEach(() => {
+            mockConn.execute.mockReset()
+        })
+
+        it("should consume weapons from inventory", async () => {
+            mockConn.execute.mockResolvedValue([{ affectedRows: 1 }])
+
+            const weapons = { "0": 2, "2": 1 }
+            const result = await dbConsumeWeapons(1, weapons, mockConn)
+
+            expect(result).toBe(true)
+            // Should be called once per weapon type, plus one for cleanup
+            expect(mockConn.execute).toHaveBeenCalledTimes(3)
+            // Parameters: [count, userId, itemId]
+            expect(mockConn.execute).toHaveBeenCalledWith(
+                expect.stringContaining("UPDATE user_inventory"),
+                [2, 1, "0"]
+            )
+            expect(mockConn.execute).toHaveBeenCalledWith(
+                expect.stringContaining("UPDATE user_inventory"),
+                [1, 1, "2"]
+            )
+            expect(mockConn.execute).toHaveBeenCalledWith(
+                expect.stringContaining("DELETE FROM user_inventory"),
+                [1]
+            )
+        })
+
+        it("should skip weapons with zero count", async () => {
+            mockConn.execute.mockResolvedValue([{ affectedRows: 1 }])
+
+            const weapons = { "0": 0, "2": 1 }
+            const result = await dbConsumeWeapons(1, weapons, mockConn)
+
+            expect(result).toBe(true)
+            // Only one weapon update + cleanup
+            expect(mockConn.execute).toHaveBeenCalledTimes(2)
+        })
+
+        it("should return false on error", async () => {
+            mockConn.execute.mockRejectedValue(new Error("DB error"))
+
+            const result = await dbConsumeWeapons(1, { "0": 1 }, mockConn)
+
+            expect(result).toBe(false)
+        })
+    })
+
+    describe("dbGetSessionUserId", () => {
+        it("should return user ID for player 0", async () => {
+            mockExecute.mockResolvedValue([[{ user_id: 10 }]])
+
+            const result = await dbGetSessionUserId("1000", 0)
+
+            expect(result).toBe(10)
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("user_one_id"),
+                ["1000"]
+            )
+        })
+
+        it("should return user ID for player 1", async () => {
+            mockExecute.mockResolvedValue([[{ user_id: 20 }]])
+
+            const result = await dbGetSessionUserId("1000", 1)
+
+            expect(result).toBe(20)
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("user_two_id"),
+                ["1000"]
+            )
+        })
+
+        it("should return null when session not found", async () => {
+            mockExecute.mockResolvedValue([[]])
+
+            const result = await dbGetSessionUserId("9999", 0)
+
+            expect(result).toBeNull()
+        })
+
+        it("should return null on error", async () => {
+            mockExecute.mockRejectedValue(new Error("DB error"))
+
+            const result = await dbGetSessionUserId("1000", 0)
+
+            expect(result).toBeNull()
+        })
+    })
+})

--- a/db/navalclash/weapons.test.js
+++ b/db/navalclash/weapons.test.js
@@ -38,7 +38,7 @@ describe("db/navalclash/weapons", () => {
 
             const result = await dbGetUserWeaponInventory(1)
 
-            expect(result).toEqual({ "0": 5, "2": 3 })
+            expect(result).toEqual({ 0: 5, 2: 3 })
             expect(mockExecute).toHaveBeenCalledWith(
                 expect.stringContaining("SELECT item_id, quantity"),
                 [1]
@@ -64,7 +64,7 @@ describe("db/navalclash/weapons", () => {
 
     describe("dbGetTrackedWeapons", () => {
         it("should return tracked weapons for player 0", async () => {
-            const tracked = { "0": 2, "1": 1 }
+            const tracked = { 0: 2, 1: 1 }
             mockExecute.mockResolvedValue([[{ tracked }]])
 
             const result = await dbGetTrackedWeapons("1000", 0)
@@ -77,7 +77,7 @@ describe("db/navalclash/weapons", () => {
         })
 
         it("should return tracked weapons for player 1", async () => {
-            const tracked = { "2": 3 }
+            const tracked = { 2: 3 }
             mockExecute.mockResolvedValue([[{ tracked }]])
 
             const result = await dbGetTrackedWeapons("1000", 1)
@@ -118,7 +118,7 @@ describe("db/navalclash/weapons", () => {
         it("should set tracked weapons for player 0", async () => {
             mockExecute.mockResolvedValue([{ affectedRows: 1 }])
 
-            const weapons = { "0": 2, "2": 1 }
+            const weapons = { 0: 2, 2: 1 }
             const result = await dbSetTrackedWeapons("1000", 0, weapons)
 
             expect(result).toBe(true)
@@ -131,7 +131,7 @@ describe("db/navalclash/weapons", () => {
         it("should set tracked weapons for player 1", async () => {
             mockExecute.mockResolvedValue([{ affectedRows: 1 }])
 
-            const weapons = { "1": 1 }
+            const weapons = { 1: 1 }
             const result = await dbSetTrackedWeapons("1000", 1, weapons)
 
             expect(result).toBe(true)
@@ -256,7 +256,7 @@ describe("db/navalclash/weapons", () => {
         it("should consume weapons from inventory", async () => {
             mockConn.execute.mockResolvedValue([{ affectedRows: 1 }])
 
-            const weapons = { "0": 2, "2": 1 }
+            const weapons = { 0: 2, 2: 1 }
             const result = await dbConsumeWeapons(1, weapons, mockConn)
 
             expect(result).toBe(true)
@@ -280,7 +280,7 @@ describe("db/navalclash/weapons", () => {
         it("should skip weapons with zero count", async () => {
             mockConn.execute.mockResolvedValue([{ affectedRows: 1 }])
 
-            const weapons = { "0": 0, "2": 1 }
+            const weapons = { 0: 0, 2: 1 }
             const result = await dbConsumeWeapons(1, weapons, mockConn)
 
             expect(result).toBe(true)
@@ -291,7 +291,7 @@ describe("db/navalclash/weapons", () => {
         it("should return false on error", async () => {
             mockConn.execute.mockRejectedValue(new Error("DB error"))
 
-            const result = await dbConsumeWeapons(1, { "0": 1 }, mockConn)
+            const result = await dbConsumeWeapons(1, { 0: 1 }, mockConn)
 
             expect(result).toBe(false)
         })

--- a/middleware/navalEncryption.js
+++ b/middleware/navalEncryption.js
@@ -1,0 +1,122 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ */
+
+const {
+    aesGcmDecrypt,
+    aesGcmEncrypt,
+    validateDeviceToken,
+    tokenToBase64,
+} = require("../utils/encryption")
+const { dbGetDeviceKey } = require("../db/navalclash/keys")
+const { logger } = require("../utils/logger")
+
+// Generic error response - never leak details to client
+const PROTOCOL_ERROR = { error: "PROTOCOL_ERROR" }
+
+/**
+ * Parses binary request format.
+ * Format: [32 byte token][12 byte IV][ciphertext+tag]
+ *
+ * @param {Buffer} body - Raw request body
+ * @returns {{ token: Buffer, iv: Buffer, ciphertext: Buffer }}
+ * @throws {Error} If body is too short
+ */
+function parseBinaryRequest(body) {
+    // Minimum: 32 (token) + 12 (IV) + 16 (tag) + 1 (min ciphertext)
+    if (!Buffer.isBuffer(body) || body.length < 61) {
+        throw new Error("Request too short")
+    }
+
+    const token = body.slice(0, 32)
+    const iv = body.slice(32, 44)
+    const ciphertext = body.slice(44)
+
+    return { token, iv, ciphertext }
+}
+
+/**
+ * Builds binary response format.
+ * Format: [12 byte IV][ciphertext+tag]
+ *
+ * @param {Buffer} iv - 12-byte IV
+ * @param {Buffer} ciphertext - Ciphertext with tag appended
+ * @returns {Buffer}
+ */
+function buildBinaryResponse(iv, ciphertext) {
+    return Buffer.concat([iv, ciphertext])
+}
+
+/**
+ * Express middleware for encrypted Naval Clash requests.
+ * Expects raw binary body (use express.raw() before this middleware).
+ *
+ * Decrypts the request, replaces req.body with parsed JSON,
+ * and overrides res.json() to encrypt responses.
+ *
+ * @param {Object} req - Express request
+ * @param {Object} res - Express response
+ * @param {Function} next - Express next middleware
+ */
+async function navalEncryption(req, res, next) {
+    // Parse binary request
+    let token, iv, ciphertext
+    try {
+        ;({ token, iv, ciphertext } = parseBinaryRequest(req.body))
+    } catch (error) {
+        logger.error({}, "Encryption: parse error:", error.message)
+        return res.status(400).json(PROTOCOL_ERROR)
+    }
+
+    // Validate token (HMAC + expiry check, no DB needed)
+    const tokenResult = validateDeviceToken(token)
+    if (!tokenResult.valid) {
+        if (tokenResult.expired) {
+            return res.status(401).json({ error: "TOKEN_EXPIRED" })
+        }
+        logger.error({}, "Encryption: invalid token HMAC")
+        return res.status(401).json(PROTOCOL_ERROR)
+    }
+
+    // Look up encryption key by token
+    const tokenBase64 = tokenToBase64(token)
+    const keyRecord = await dbGetDeviceKey(tokenBase64)
+    if (!keyRecord) {
+        logger.error(
+            {},
+            "Encryption: token not in DB:",
+            tokenBase64.substring(0, 8) + "..."
+        )
+        return res.status(401).json(PROTOCOL_ERROR)
+    }
+
+    // Decrypt request body
+    try {
+        const plaintext = aesGcmDecrypt(keyRecord.key, iv, ciphertext)
+        req.body = JSON.parse(plaintext.toString("utf8"))
+        req.navalDeviceUuid = keyRecord.deviceUuid
+        req.navalKey = keyRecord.key
+    } catch (error) {
+        logger.error({}, "Encryption: decrypt error:", error.message)
+        return res.status(400).json(PROTOCOL_ERROR)
+    }
+
+    // Override res.json to encrypt the response
+    const originalSend = res.send.bind(res)
+    res.json = (body) => {
+        const plaintext = Buffer.from(JSON.stringify(body), "utf8")
+        const { iv: respIv, ciphertext: respCiphertext } = aesGcmEncrypt(
+            req.navalKey,
+            plaintext
+        )
+
+        res.set("Content-Type", "application/octet-stream")
+        return originalSend(buildBinaryResponse(respIv, respCiphertext))
+    }
+
+    next()
+}
+
+module.exports = { navalEncryption, parseBinaryRequest, buildBinaryResponse }

--- a/middleware/navalEncryption.test.js
+++ b/middleware/navalEncryption.test.js
@@ -1,0 +1,241 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ */
+
+const crypto = require("crypto")
+
+// Mock dependencies before requiring module
+const mockValidateDeviceToken = jest.fn()
+const mockTokenToBase64 = jest.fn()
+const mockAesGcmDecrypt = jest.fn()
+const mockAesGcmEncrypt = jest.fn()
+const mockDbGetDeviceKey = jest.fn()
+
+jest.mock("../utils/encryption", () => ({
+    validateDeviceToken: mockValidateDeviceToken,
+    tokenToBase64: mockTokenToBase64,
+    aesGcmDecrypt: mockAesGcmDecrypt,
+    aesGcmEncrypt: mockAesGcmEncrypt,
+}))
+
+jest.mock("../db/navalclash/keys", () => ({
+    dbGetDeviceKey: mockDbGetDeviceKey,
+}))
+
+jest.mock("../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}))
+
+const {
+    navalEncryption,
+    parseBinaryRequest,
+    buildBinaryResponse,
+} = require("./navalEncryption")
+
+describe("parseBinaryRequest", () => {
+    it("should parse valid binary request", () => {
+        const token = crypto.randomBytes(32)
+        const iv = crypto.randomBytes(12)
+        const ciphertext = crypto.randomBytes(33) // 16 tag + 17 data
+
+        const body = Buffer.concat([token, iv, ciphertext])
+        const result = parseBinaryRequest(body)
+
+        expect(result.token).toEqual(token)
+        expect(result.iv).toEqual(iv)
+        expect(result.ciphertext).toEqual(ciphertext)
+    })
+
+    it("should reject body too short", () => {
+        expect(() => parseBinaryRequest(Buffer.alloc(60))).toThrow(
+            "Request too short"
+        )
+    })
+
+    it("should reject non-buffer input", () => {
+        expect(() => parseBinaryRequest("not-a-buffer")).toThrow(
+            "Request too short"
+        )
+    })
+
+    it("should accept minimum valid length (61 bytes)", () => {
+        const body = Buffer.alloc(61)
+        const result = parseBinaryRequest(body)
+        expect(result.token.length).toBe(32)
+        expect(result.iv.length).toBe(12)
+        expect(result.ciphertext.length).toBe(17)
+    })
+})
+
+describe("buildBinaryResponse", () => {
+    it("should concatenate IV and ciphertext", () => {
+        const iv = Buffer.from("123456789012") // 12 bytes
+        const ciphertext = Buffer.from("encrypted-data-with-tag")
+
+        const result = buildBinaryResponse(iv, ciphertext)
+
+        expect(result.length).toBe(iv.length + ciphertext.length)
+        expect(result.slice(0, 12)).toEqual(iv)
+        expect(result.slice(12)).toEqual(ciphertext)
+    })
+})
+
+describe("navalEncryption middleware", () => {
+    let req, res, next
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+
+        req = {
+            body: null,
+        }
+        res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn().mockReturnThis(),
+            send: jest.fn().mockReturnThis(),
+            set: jest.fn().mockReturnThis(),
+        }
+        next = jest.fn()
+    })
+
+    it("should return 400 for body too short", async () => {
+        req.body = Buffer.alloc(10)
+
+        await navalEncryption(req, res, next)
+
+        expect(res.status).toHaveBeenCalledWith(400)
+        expect(res.json).toHaveBeenCalledWith({ error: "PROTOCOL_ERROR" })
+        expect(next).not.toHaveBeenCalled()
+    })
+
+    it("should return 401 for invalid token HMAC", async () => {
+        req.body = Buffer.alloc(100)
+        mockValidateDeviceToken.mockReturnValue({ valid: false })
+
+        await navalEncryption(req, res, next)
+
+        expect(res.status).toHaveBeenCalledWith(401)
+        expect(res.json).toHaveBeenCalledWith({ error: "PROTOCOL_ERROR" })
+        expect(next).not.toHaveBeenCalled()
+    })
+
+    it("should return 401 TOKEN_EXPIRED for expired token", async () => {
+        req.body = Buffer.alloc(100)
+        mockValidateDeviceToken.mockReturnValue({
+            valid: false,
+            expired: true,
+        })
+
+        await navalEncryption(req, res, next)
+
+        expect(res.status).toHaveBeenCalledWith(401)
+        expect(res.json).toHaveBeenCalledWith({ error: "TOKEN_EXPIRED" })
+        expect(next).not.toHaveBeenCalled()
+    })
+
+    it("should return 401 when token not in DB", async () => {
+        req.body = Buffer.alloc(100)
+        mockValidateDeviceToken.mockReturnValue({ valid: true })
+        mockTokenToBase64.mockReturnValue("dGVzdC10b2tlbi1iYXNlNjQ=")
+        mockDbGetDeviceKey.mockResolvedValue(null)
+
+        await navalEncryption(req, res, next)
+
+        expect(res.status).toHaveBeenCalledWith(401)
+        expect(res.json).toHaveBeenCalledWith({ error: "PROTOCOL_ERROR" })
+        expect(next).not.toHaveBeenCalled()
+    })
+
+    it("should return 400 on decrypt failure", async () => {
+        req.body = Buffer.alloc(100)
+        const aesKey = crypto.randomBytes(32)
+
+        mockValidateDeviceToken.mockReturnValue({ valid: true })
+        mockTokenToBase64.mockReturnValue("token-b64")
+        mockDbGetDeviceKey.mockResolvedValue({
+            key: aesKey,
+            deviceUuid: "test-uuid",
+        })
+        mockAesGcmDecrypt.mockImplementation(() => {
+            throw new Error("Decryption failed")
+        })
+
+        await navalEncryption(req, res, next)
+
+        expect(res.status).toHaveBeenCalledWith(400)
+        expect(res.json).toHaveBeenCalledWith({ error: "PROTOCOL_ERROR" })
+        expect(next).not.toHaveBeenCalled()
+    })
+
+    it("should decrypt request and call next on success", async () => {
+        const aesKey = crypto.randomBytes(32)
+        const decryptedPayload = { type: "connect", player: "TestPlayer" }
+
+        req.body = Buffer.alloc(100)
+
+        mockValidateDeviceToken.mockReturnValue({ valid: true })
+        mockTokenToBase64.mockReturnValue("token-b64")
+        mockDbGetDeviceKey.mockResolvedValue({
+            key: aesKey,
+            deviceUuid: "device-123",
+        })
+        mockAesGcmDecrypt.mockReturnValue(
+            Buffer.from(JSON.stringify(decryptedPayload))
+        )
+
+        await navalEncryption(req, res, next)
+
+        expect(req.body).toEqual(decryptedPayload)
+        expect(req.navalDeviceUuid).toBe("device-123")
+        expect(req.navalKey).toEqual(aesKey)
+        expect(next).toHaveBeenCalled()
+    })
+
+    it("should override res.json to send encrypted binary", async () => {
+        const aesKey = crypto.randomBytes(32)
+        const decryptedPayload = { type: "connect" }
+        const respIv = crypto.randomBytes(12)
+        const respCiphertext = Buffer.from("encrypted-response")
+
+        req.body = Buffer.alloc(100)
+
+        mockValidateDeviceToken.mockReturnValue({ valid: true })
+        mockTokenToBase64.mockReturnValue("token-b64")
+        mockDbGetDeviceKey.mockResolvedValue({
+            key: aesKey,
+            deviceUuid: "device-123",
+        })
+        mockAesGcmDecrypt.mockReturnValue(
+            Buffer.from(JSON.stringify(decryptedPayload))
+        )
+        mockAesGcmEncrypt.mockReturnValue({
+            iv: respIv,
+            ciphertext: respCiphertext,
+        })
+
+        await navalEncryption(req, res, next)
+
+        // Call the overridden res.json
+        const responseBody = { type: "ok", sid: "12345" }
+        res.json(responseBody)
+
+        expect(mockAesGcmEncrypt).toHaveBeenCalledWith(
+            aesKey,
+            Buffer.from(JSON.stringify(responseBody), "utf8")
+        )
+        expect(res.set).toHaveBeenCalledWith(
+            "Content-Type",
+            "application/octet-stream"
+        )
+        expect(res.send).toHaveBeenCalledWith(
+            Buffer.concat([respIv, respCiphertext])
+        )
+    })
+})

--- a/routes/navalclash.js
+++ b/routes/navalclash.js
@@ -32,6 +32,8 @@ function router(app) {
         finish,
         dutchMove,
         shipMove,
+        weaponsList,
+        radarActivation,
     } = require("../services/navalclash/gameService")
     const {
         addRival,
@@ -48,6 +50,10 @@ function router(app) {
         getInventory,
         internalBuy,
     } = require("../services/navalclash/shopService")
+    const {
+        exportProfile,
+        importProfile,
+    } = require("../services/navalclash/profileService")
 
     // Phase 1: Connect & Users
     r.post("/connect", connect)
@@ -68,6 +74,8 @@ function router(app) {
     r.post("/fin", finish)
     r.post("/dutch", dutchMove)
     r.post("/smove", shipMove)
+    r.post("/wpl", weaponsList)
+    r.post("/anr", radarActivation)
 
     // Phase 4: Social Features
     r.post("/umarker", userMarker)
@@ -84,10 +92,20 @@ function router(app) {
     r.post("/iby", internalBuy)
     r.post("/inventory", getInventory)
 
-    // Phase 6 routes will be added as that phase is implemented
-    // r.post("/ufv", syncProfile)
-    // r.post("/uexp", exportProfile)
-    // r.post("/uimp", importProfile)
+    // Phase 6: Profile Management
+    r.post("/uexp", exportProfile)
+    r.post("/uimp", importProfile)
+    // r.post("/ufv", syncProfile) - TODO: implement profile sync
+
+    // Debug/test endpoint for remote logging
+    r.post("/echo", (req, res) => {
+        const { device, tag, msg, ts } = req.body
+        const timestamp = ts ? new Date(ts).toISOString() : new Date().toISOString()
+        const deviceTag = device || "UNKNOWN"
+        const logTag = tag || "LOG"
+        console.log(`[${timestamp}] [${deviceTag}] [${logTag}] ${msg || JSON.stringify(req.body)}`)
+        res.json({ status: "ok" })
+    })
 
     return r
 }

--- a/routes/navalclash.js
+++ b/routes/navalclash.js
@@ -46,6 +46,7 @@ function router(app) {
     const {
         getItemsList,
         getInventory,
+        internalBuy,
     } = require("../services/navalclash/shopService")
 
     // Phase 1: Connect & Users
@@ -80,6 +81,7 @@ function router(app) {
     // Phase 5: Leaderboard & Shop (no Google billing)
     r.post("/topTen", getTopScores)
     r.post("/ils", getItemsList)
+    r.post("/iby", internalBuy)
     r.post("/inventory", getInventory)
 
     // Phase 6 routes will be added as that phase is implemented

--- a/routes/navalclash.js
+++ b/routes/navalclash.js
@@ -43,7 +43,10 @@ function router(app) {
         userMarker,
     } = require("../services/navalclash/socialService")
     const { getTopScores } = require("../services/navalclash/leaderboardService")
-    const { getInventory } = require("../services/navalclash/shopService")
+    const {
+        getItemsList,
+        getInventory,
+    } = require("../services/navalclash/shopService")
 
     // Phase 1: Connect & Users
     r.post("/connect", connect)
@@ -76,6 +79,7 @@ function router(app) {
 
     // Phase 5: Leaderboard & Shop (no Google billing)
     r.post("/topTen", getTopScores)
+    r.post("/ils", getItemsList)
     r.post("/inventory", getInventory)
 
     // Phase 6 routes will be added as that phase is implemented

--- a/routes/navalclash.js
+++ b/routes/navalclash.js
@@ -43,6 +43,7 @@ function router(app) {
         getRecentOpponents,
         getOnlineUsers,
         userMarker,
+        userAnswer,
     } = require("../services/navalclash/socialService")
     const { getTopScores } = require("../services/navalclash/leaderboardService")
     const {
@@ -53,6 +54,7 @@ function router(app) {
     const {
         exportProfile,
         importProfile,
+        syncProfile,
     } = require("../services/navalclash/profileService")
 
     // Phase 1: Connect & Users
@@ -85,6 +87,7 @@ function router(app) {
     r.post("/usearch", searchUsers)
     r.post("/ugetrcnt", getRecentOpponents)
     r.post("/ugetair", getOnlineUsers)
+    r.post("/uanswer", userAnswer)
 
     // Phase 5: Leaderboard & Shop (no Google billing)
     r.post("/topTen", getTopScores)
@@ -95,7 +98,7 @@ function router(app) {
     // Phase 6: Profile Management
     r.post("/uexp", exportProfile)
     r.post("/uimp", importProfile)
-    // r.post("/ufv", syncProfile) - TODO: implement profile sync
+    r.post("/ufv", syncProfile)
 
     // Debug/test endpoint for remote logging
     r.post("/echo", (req, res) => {

--- a/routes/navalclash.js
+++ b/routes/navalclash.js
@@ -5,6 +5,8 @@
  */
 
 const express = require("express")
+const { navalEncryption } = require("../middleware/navalEncryption")
+const { handshake } = require("../services/navalclash/handshakeService")
 
 /**
  * Creates and configures the Naval Clash router.
@@ -14,6 +16,15 @@ const express = require("express")
  */
 function router(app) {
     const r = express.Router()
+
+    // Parse binary bodies for encrypted requests
+    r.use(express.raw({ type: "application/octet-stream", limit: "1mb" }))
+
+    // Handshake uses RSA encryption (establishes AES key) - before middleware
+    r.post("/handshake", handshake)
+
+    // All other routes use AES encryption via middleware
+    r.use(navalEncryption)
 
     // Import services
     const {
@@ -45,7 +56,9 @@ function router(app) {
         userMarker,
         userAnswer,
     } = require("../services/navalclash/socialService")
-    const { getTopScores } = require("../services/navalclash/leaderboardService")
+    const {
+        getTopScores,
+    } = require("../services/navalclash/leaderboardService")
     const {
         getItemsList,
         getInventory,
@@ -103,10 +116,14 @@ function router(app) {
     // Debug/test endpoint for remote logging
     r.post("/echo", (req, res) => {
         const { device, tag, msg, ts } = req.body
-        const timestamp = ts ? new Date(ts).toISOString() : new Date().toISOString()
+        const timestamp = ts
+            ? new Date(ts).toISOString()
+            : new Date().toISOString()
         const deviceTag = device || "UNKNOWN"
         const logTag = tag || "LOG"
-        console.log(`[${timestamp}] [${deviceTag}] [${logTag}] ${msg || JSON.stringify(req.body)}`)
+        console.log(
+            `[${timestamp}] [${deviceTag}] [${logTag}] ${msg || JSON.stringify(req.body)}`
+        )
         res.json({ status: "ok" })
     })
 

--- a/services/navalclash/clusterBroker.js
+++ b/services/navalclash/clusterBroker.js
@@ -154,7 +154,10 @@ const setupWorkers = new Set()
  */
 function setupWorkerHandlers(worker) {
     if (setupWorkers.has(worker.id)) {
-        logger.debug({ workerId: worker.id }, "Worker handlers already set up, skipping")
+        logger.debug(
+            { workerId: worker.id },
+            "Worker handlers already set up, skipping"
+        )
         return
     }
     setupWorkers.add(worker.id)
@@ -200,7 +203,10 @@ function setupMasterBroker() {
     }
 
     cluster.on("fork", (worker) => {
-        logger.debug({ workerId: worker.id }, "Setting up handlers for new worker")
+        logger.debug(
+            { workerId: worker.id },
+            "Setting up handlers for new worker"
+        )
         setupWorkerHandlers(worker)
     })
 

--- a/services/navalclash/connectService.js
+++ b/services/navalclash/connectService.js
@@ -485,7 +485,7 @@ async function terminateUserSessions(conn, userId) {
             status = ?,
             finished_at = NOW(3)
          WHERE (user_one_id = ? OR user_two_id = ?)
-           AND status < 1`,
+           AND status <= 1`,
         [SESSION_STATUS_TERMINATED_DUPLICATE, userId, userId]
     )
 

--- a/services/navalclash/connectService.js
+++ b/services/navalclash/connectService.js
@@ -597,8 +597,9 @@ async function reconnect(req, res) {
     }
 
     try {
+        // Only allow reconnecting to active sessions (WAITING or IN_PROGRESS)
         const [rows] = await pool.execute(
-            "SELECT * FROM game_sessions WHERE id = ? AND status < 10",
+            "SELECT * FROM game_sessions WHERE id = ? AND status <= 1",
             [sid]
         )
 

--- a/services/navalclash/connectService.js
+++ b/services/navalclash/connectService.js
@@ -352,13 +352,25 @@ async function joinExistingSession(conn, session, userId, version) {
  * @param {number|null} targetRivalId - Target rival user ID for personal games (null for random)
  * @returns {Promise<BigInt>} New session ID (even)
  */
-async function createNewSession(conn, userId, version, gameVariant, targetRivalId = null) {
+async function createNewSession(
+    conn,
+    userId,
+    version,
+    gameVariant,
+    targetRivalId = null
+) {
     const sessionId = generateSessionId()
     const sessionIdStr = sessionId.toString()
 
     const isPersonal = targetRivalId !== null
     logger.info(
-        { sid: sessionIdStr, uid: userId, variant: gameVariant, targetRivalId, isPersonal },
+        {
+            sid: sessionIdStr,
+            uid: userId,
+            variant: gameVariant,
+            targetRivalId,
+            isPersonal,
+        },
         `Creating new ${isPersonal ? "personal" : "random"} waiting session as player 0`
     )
 
@@ -368,7 +380,14 @@ async function createNewSession(conn, userId, version, gameVariant, targetRivalI
         `INSERT INTO game_sessions
             (id, user_one_id, user_one_connected_at, version_one, game_variant, game_type, target_rival_id, status)
          VALUES (?, ?, NOW(3), ?, ?, ?, ?, 0)`,
-        [sessionIdStr, userId, version, gameVariant, isPersonal ? 1 : 0, targetRivalId]
+        [
+            sessionIdStr,
+            userId,
+            version,
+            gameVariant,
+            isPersonal ? 1 : 0,
+            targetRivalId,
+        ]
     )
 
     return sessionId

--- a/services/navalclash/connectService.js
+++ b/services/navalclash/connectService.js
@@ -4,7 +4,11 @@
  * All rights reserved.
  */
 
-const { pool, dbUpdateLocalStats } = require("../../db/navalclash")
+const {
+    pool,
+    dbUpdateLocalStats,
+    dbFindUserByUuidAndName,
+} = require("../../db/navalclash")
 const { logger } = require("../../utils/logger")
 const { getMinVersion, isMaintenanceMode } = require("./setupService")
 const { MSG, SESSION_STATUS, VERSION } = require("./constants")
@@ -420,7 +424,128 @@ async function acquireMatchmakingLock(conn, gameVariant) {
 }
 
 /**
+ * Searches for rival's waiting session that the current user can join.
+ * Matches if the rival is waiting for us specifically, or for anyone (random).
+ *
+ * @param {Object} conn - Database connection
+ * @param {number} rivalId - Rival's user ID
+ * @param {number} userId - Current user's ID
+ * @param {number} gameVariant - Game variant
+ * @returns {Promise<Object|null>} Waiting session or null
+ */
+async function findRivalWaitingSession(conn, rivalId, userId, gameVariant) {
+    const [rows] = await conn.execute(
+        `SELECT gs.*, u.name as user_one_name
+         FROM game_sessions gs
+         JOIN users u ON u.id = gs.user_one_id
+         WHERE gs.status = 0
+           AND gs.user_two_id IS NULL
+           AND gs.user_one_id = ?
+           AND gs.game_variant = ?
+           AND gs.last_seen_one > DATE_SUB(NOW(3), INTERVAL 45 SECOND)
+           AND (gs.target_rival_id IS NULL OR gs.target_rival_id = ?)
+         ORDER BY gs.created_at ASC
+         LIMIT 1`,
+        [rivalId, gameVariant, userId]
+    )
+    return rows.length > 0 ? rows[0] : null
+}
+
+/**
+ * Searches for a personal session that targets the given user.
+ * Used when a random player connects and someone is waiting for them.
+ *
+ * @param {Object} conn - Database connection
+ * @param {number} userId - Current user's ID (the target)
+ * @param {number} gameVariant - Game variant
+ * @returns {Promise<Object|null>} Waiting session or null
+ */
+async function findPersonalSessionTargetingMe(
+    conn,
+    userId,
+    gameVariant
+) {
+    const [rows] = await conn.execute(
+        `SELECT gs.*, u.name as user_one_name
+         FROM game_sessions gs
+         JOIN users u ON u.id = gs.user_one_id
+         WHERE gs.status = 0
+           AND gs.user_two_id IS NULL
+           AND gs.target_rival_id = ?
+           AND gs.game_variant = ?
+           AND gs.last_seen_one > DATE_SUB(NOW(3), INTERVAL 45 SECOND)
+         ORDER BY gs.created_at ASC
+         LIMIT 1`,
+        [userId, gameVariant]
+    )
+    return rows.length > 0 ? rows[0] : null
+}
+
+/**
+ * Searches for a random waiting session (excludes personal sessions).
+ *
+ * @param {Object} conn - Database connection
+ * @param {number} userId - Current user's ID (to exclude self-matching)
+ * @param {number} gameVariant - Game variant
+ * @param {number} version - Joiner's app version
+ * @returns {Promise<Object|null>} Waiting session or null
+ */
+async function findRandomWaitingSession(
+    conn,
+    userId,
+    gameVariant,
+    version
+) {
+    const joinerIsAgent = isAgentVersion(version)
+
+    let rows
+    if (joinerIsAgent) {
+        // Agent joining: only match with humans, exclude personal sessions
+        ;[rows] = await conn.execute(
+            `SELECT gs.*, u.name as user_one_name
+             FROM game_sessions gs
+             JOIN users u ON u.id = gs.user_one_id
+             WHERE gs.status = 0
+               AND gs.user_two_id IS NULL
+               AND gs.user_one_id != ?
+               AND gs.game_variant = ?
+               AND gs.target_rival_id IS NULL
+               AND gs.last_seen_one > DATE_SUB(NOW(3), INTERVAL 45 SECOND)
+               AND (gs.version_one < ? OR gs.version_one > ?)
+             ORDER BY gs.created_at ASC
+             LIMIT 1`,
+            [userId, gameVariant, VERSION.AGENT_MIN, VERSION.AGENT_MAX]
+        )
+    } else {
+        // Human joining: match with anyone, exclude personal sessions
+        ;[rows] = await conn.execute(
+            `SELECT gs.*, u.name as user_one_name
+             FROM game_sessions gs
+             JOIN users u ON u.id = gs.user_one_id
+             WHERE gs.status = 0
+               AND gs.user_two_id IS NULL
+               AND gs.user_one_id != ?
+               AND gs.game_variant = ?
+               AND gs.target_rival_id IS NULL
+               AND gs.last_seen_one > DATE_SUB(NOW(3), INTERVAL 45 SECOND)
+             ORDER BY gs.created_at ASC
+             LIMIT 1`,
+            [userId, gameVariant]
+        )
+    }
+
+    return rows.length > 0 ? rows[0] : null
+}
+
+/**
  * Finds a waiting session or creates a new one.
+ *
+ * Matchmaking priority:
+ * 1. Personal game (has rival): find rival's session (targeting me or random), else create personal session
+ * 2. Random game: check for personal sessions targeting me first, then regular random matchmaking
+ *
+ * Personal sessions are excluded from random matchmaking so random players
+ * don't steal sessions meant for a specific rival.
  *
  * @param {Object} conn - Database connection
  * @param {Object} user - User object
@@ -430,89 +555,135 @@ async function acquireMatchmakingLock(conn, gameVariant) {
 async function findOrCreateSession(conn, user, body) {
     const gameVariant = body.var || 1
     const version = body.v || 0
-    const hasRival = body.rival && body.rival.id
+    // Client sends rival as User.serializeJSON(): "i" = DB integer ID, "id" = UUID
+    // On rematch, "i" may be 0 if the client didn't have the DB ID - resolve by UUID+name
+    let rivalId = body.rival?.i || null
     const ctx = { uid: user.id, variant: gameVariant }
 
-    if (hasRival) {
-        logger.debug(
-            { ...ctx, rivalId: body.rival.id },
-            "Personal game requested, skipping matchmaking"
+    if (!rivalId && body.rival?.id && body.rival?.nam) {
+        const rivalUser = await dbFindUserByUuidAndName(
+            body.rival.id,
+            body.rival.nam
         )
-    }
-
-    if (!hasRival) {
-        // Acquire matchmaking lock to prevent race conditions.
-        // Without this, two players connecting simultaneously when no
-        // waiting session exists would both create their own sessions.
-        logger.debug(ctx, "Acquiring matchmaking lock")
-        await acquireMatchmakingLock(conn, gameVariant)
-
-        // Check if joiner is an AI agent - agents can only play vs humans
-        const joinerIsAgent = isAgentVersion(version)
-        logger.debug(
-            { ...ctx, joinerIsAgent, version },
-            "Searching for waiting session"
-        )
-
-        let waitingSessions
-        if (joinerIsAgent) {
-            // Agent joining - only match with humans (exclude agent versions)
-            ;[waitingSessions] = await conn.execute(
-                `SELECT gs.*, u.name as user_one_name
-                 FROM game_sessions gs
-                 JOIN users u ON u.id = gs.user_one_id
-                 WHERE gs.status = 0
-                   AND gs.user_two_id IS NULL
-                   AND gs.user_one_id != ?
-                   AND gs.game_variant = ?
-                   AND gs.last_seen_one > DATE_SUB(NOW(3), INTERVAL 45 SECOND)
-                   AND (gs.version_one < ? OR gs.version_one > ?)
-                 ORDER BY gs.created_at ASC
-                 LIMIT 1`,
-                [user.id, gameVariant, VERSION.AGENT_MIN, VERSION.AGENT_MAX]
-            )
-        } else {
-            // Human joining - can match with anyone
-            ;[waitingSessions] = await conn.execute(
-                `SELECT gs.*, u.name as user_one_name
-                 FROM game_sessions gs
-                 JOIN users u ON u.id = gs.user_one_id
-                 WHERE gs.status = 0
-                   AND gs.user_two_id IS NULL
-                   AND gs.user_one_id != ?
-                   AND gs.game_variant = ?
-                   AND gs.last_seen_one > DATE_SUB(NOW(3), INTERVAL 45 SECOND)
-                 ORDER BY gs.created_at ASC
-                 LIMIT 1`,
-                [user.id, gameVariant]
+        if (rivalUser) {
+            rivalId = rivalUser.id
+            logger.debug(
+                { ...ctx, rivalId, rivalUuid: body.rival.id },
+                "Resolved rival ID from UUID"
             )
         }
+    }
 
-        if (waitingSessions.length > 0) {
-            logger.debug(
-                { ...ctx, foundSid: waitingSessions[0].id },
-                `Found ${waitingSessions.length} waiting session(s), joining first`
+    const hasRival = !!rivalId
+
+    // Always acquire matchmaking lock to prevent race conditions.
+    // Without this, two players connecting simultaneously could both
+    // create their own sessions instead of being matched together.
+    logger.debug(ctx, "Acquiring matchmaking lock")
+    await acquireMatchmakingLock(conn, gameVariant)
+
+    if (hasRival) {
+        // PERSONAL GAME: find rival's waiting session
+        logger.debug(
+            { ...ctx, rivalId },
+            "Personal game requested, searching for rival's session"
+        )
+
+        const rivalSession = await findRivalWaitingSession(
+            conn,
+            rivalId,
+            user.id,
+            gameVariant
+        )
+
+        if (rivalSession) {
+            logger.info(
+                { ...ctx, rivalId, foundSid: rivalSession.id },
+                "Found rival's waiting session, joining"
             )
             const sessionId = await joinExistingSession(
                 conn,
-                waitingSessions[0],
+                rivalSession,
                 user.id,
                 version
             )
             return { sessionId, isNewSession: false }
         }
-        logger.debug(ctx, "No waiting sessions found")
+
+        logger.debug(
+            { ...ctx, rivalId },
+            "Rival not waiting, creating personal session"
+        )
+        const sessionId = await createNewSession(
+            conn,
+            user.id,
+            version,
+            gameVariant,
+            rivalId
+        )
+        return { sessionId, isNewSession: true }
     }
 
-    // For personal games, extract the target rival's user ID
-    const targetRivalId = hasRival ? body.rival.id : null
+    // RANDOM GAME: first check if someone is waiting specifically for us
+    logger.debug(ctx, "Checking for personal sessions targeting me")
+    const personalSession = await findPersonalSessionTargetingMe(
+        conn,
+        user.id,
+        gameVariant
+    )
 
+    if (personalSession) {
+        logger.info(
+            {
+                ...ctx,
+                foundSid: personalSession.id,
+                waitingUid: personalSession.user_one_id,
+            },
+            "Found personal session targeting me, joining"
+        )
+        const sessionId = await joinExistingSession(
+            conn,
+            personalSession,
+            user.id,
+            version
+        )
+        return { sessionId, isNewSession: false }
+    }
+
+    // Regular random matchmaking (excludes personal sessions)
+    logger.debug(
+        { ...ctx, isAgent: isAgentVersion(version), version },
+        "Searching for random waiting session"
+    )
+
+    const randomSession = await findRandomWaitingSession(
+        conn,
+        user.id,
+        gameVariant,
+        version
+    )
+
+    if (randomSession) {
+        logger.info(
+            { ...ctx, foundSid: randomSession.id },
+            "Found random waiting session, joining"
+        )
+        const sessionId = await joinExistingSession(
+            conn,
+            randomSession,
+            user.id,
+            version
+        )
+        return { sessionId, isNewSession: false }
+    }
+
+    logger.debug(ctx, "No waiting sessions found, creating new random session")
     const sessionId = await createNewSession(
         conn,
         user.id,
         version,
         gameVariant,
-        targetRivalId
+        null
     )
     return { sessionId, isNewSession: true }
 }
@@ -556,6 +727,7 @@ async function connect(req, res) {
     const reqCtx = { name: body.player, uuid: body.uuuid?.substring(0, 8) }
 
     logger.info(reqCtx, "Connect request received")
+    logger.debug(reqCtx, "Connect body: ", JSON.stringify(body))
 
     if (!body.player || !body.uuuid || body.type !== "connect") {
         logger.warn(reqCtx, "Invalid connect request - missing required fields")

--- a/services/navalclash/connectService.js
+++ b/services/navalclash/connectService.js
@@ -322,6 +322,7 @@ async function joinExistingSession(conn, session, userId, version) {
             user_two_connected_at = NOW(3),
             version_two = ?,
             status = 1,
+            last_seen_two = NOW(3),
             updated_at = NOW(3)
          WHERE id = ? AND user_two_id IS NULL`,
         [userId, version, sessionIdStr]
@@ -378,8 +379,9 @@ async function createNewSession(
     // game_type: 0 = random, 1 = personal
     await conn.query(
         `INSERT INTO game_sessions
-            (id, user_one_id, user_one_connected_at, version_one, game_variant, game_type, target_rival_id, status)
-         VALUES (?, ?, NOW(3), ?, ?, ?, ?, 0)`,
+            (id, user_one_id, user_one_connected_at, version_one, game_variant,
+             game_type, target_rival_id, status, last_seen_one)
+         VALUES (?, ?, NOW(3), ?, ?, ?, ?, 0, NOW(3))`,
         [
             sessionIdStr,
             userId,
@@ -463,7 +465,7 @@ async function findOrCreateSession(conn, user, body) {
                    AND gs.user_two_id IS NULL
                    AND gs.user_one_id != ?
                    AND gs.game_variant = ?
-                   AND gs.updated_at > DATE_SUB(NOW(3), INTERVAL 2 MINUTE)
+                   AND gs.last_seen_one > DATE_SUB(NOW(3), INTERVAL 45 SECOND)
                    AND (gs.version_one < ? OR gs.version_one > ?)
                  ORDER BY gs.created_at ASC
                  LIMIT 1`,
@@ -479,7 +481,7 @@ async function findOrCreateSession(conn, user, body) {
                    AND gs.user_two_id IS NULL
                    AND gs.user_one_id != ?
                    AND gs.game_variant = ?
-                   AND gs.updated_at > DATE_SUB(NOW(3), INTERVAL 2 MINUTE)
+                   AND gs.last_seen_one > DATE_SUB(NOW(3), INTERVAL 45 SECOND)
                  ORDER BY gs.created_at ASC
                  LIMIT 1`,
                 [user.id, gameVariant]

--- a/services/navalclash/connectService.test.js
+++ b/services/navalclash/connectService.test.js
@@ -186,7 +186,8 @@ describe("services/navalclash/connectService", () => {
             }
 
             mockConnection.execute
-                .mockResolvedValueOnce([[{ id: 1, isbanned: 1 }]]) // getOrCreateUser
+                .mockResolvedValueOnce([]) // SET TRANSACTION ISOLATION LEVEL
+                .mockResolvedValueOnce([[{ id: 1, isbanned: 1 }]]) // find user
                 .mockResolvedValueOnce([{ affectedRows: 1 }]) // update login
 
             await connect(req, mockRes)
@@ -204,6 +205,7 @@ describe("services/navalclash/connectService", () => {
             }
 
             mockConnection.execute
+                .mockResolvedValueOnce([]) // SET TRANSACTION ISOLATION LEVEL
                 .mockResolvedValueOnce([[{ id: 1, isbanned: 0 }]]) // find user
                 .mockResolvedValueOnce([{ affectedRows: 1 }]) // update login
                 .mockResolvedValueOnce([
@@ -242,6 +244,7 @@ describe("services/navalclash/connectService", () => {
             }
 
             mockConnection.execute
+                .mockResolvedValueOnce([]) // SET TRANSACTION ISOLATION LEVEL
                 .mockResolvedValueOnce([[]]) // find user - not found
                 .mockResolvedValueOnce([{ insertId: 5 }]) // insert user
                 .mockResolvedValueOnce([[]]) // check PIN
@@ -251,7 +254,6 @@ describe("services/navalclash/connectService", () => {
                     [{ name: "maintenance_mode", int_value: 0 }],
                 ]) // config
                 .mockResolvedValueOnce([{ affectedRows: 0 }]) // terminate old sessions
-                .mockResolvedValueOnce([{ affectedRows: 1 }]) // matchmaking lock INSERT
                 .mockResolvedValueOnce([[{ game_variant: 1 }]]) // matchmaking lock SELECT FOR UPDATE
                 .mockResolvedValueOnce([[]]) // find waiting session
 
@@ -302,13 +304,13 @@ describe("services/navalclash/connectService", () => {
             }
 
             mockConnection.execute
+                .mockResolvedValueOnce([]) // SET TRANSACTION ISOLATION LEVEL
                 .mockResolvedValueOnce([[mockUser]]) // find user
                 .mockResolvedValueOnce([{ affectedRows: 1 }]) // update login
                 .mockResolvedValueOnce([
                     [{ name: "maintenance_mode", int_value: 0 }],
                 ]) // config
                 .mockResolvedValueOnce([{ affectedRows: 0 }]) // terminate old sessions
-                .mockResolvedValueOnce([{ affectedRows: 1 }]) // matchmaking lock INSERT
                 .mockResolvedValueOnce([[{ game_variant: 1 }]]) // matchmaking lock SELECT FOR UPDATE
                 .mockResolvedValueOnce([[waitingSession]]) // find waiting session
 
@@ -370,6 +372,7 @@ describe("services/navalclash/connectService", () => {
             }
 
             mockConnection.execute
+                .mockResolvedValueOnce([]) // SET TRANSACTION ISOLATION LEVEL
                 .mockResolvedValueOnce([[mockUser]]) // find user
                 .mockResolvedValueOnce([{ affectedRows: 1 }]) // update login
                 .mockResolvedValueOnce([[]]) // find device - not found
@@ -380,7 +383,6 @@ describe("services/navalclash/connectService", () => {
                     [{ name: "maintenance_mode", int_value: 0 }],
                 ]) // config
                 .mockResolvedValueOnce([{ affectedRows: 0 }]) // terminate old sessions
-                .mockResolvedValueOnce([{ affectedRows: 1 }]) // matchmaking lock INSERT
                 .mockResolvedValueOnce([[{ game_variant: 1 }]]) // matchmaking lock SELECT FOR UPDATE
                 .mockResolvedValueOnce([[]]) // find waiting session
 

--- a/services/navalclash/connectService.test.js
+++ b/services/navalclash/connectService.test.js
@@ -297,8 +297,9 @@ describe("services/navalclash/connectService", () => {
                 .mockResolvedValueOnce([{ affectedRows: 1 }]) // update PIN
                 .mockResolvedValueOnce([[mockUser]]) // fetch created user
                 .mockResolvedValueOnce([{ affectedRows: 0 }]) // terminate old sessions
-                .mockResolvedValueOnce([[{ game_variant: 1 }]]) // matchmaking lock SELECT FOR UPDATE
-                .mockResolvedValueOnce([[]]) // find waiting session
+                .mockResolvedValueOnce([[{ game_variant: 1 }]]) // matchmaking lock
+                .mockResolvedValueOnce([[]]) // personal session targeting me - none
+                .mockResolvedValueOnce([[]]) // random waiting session - none
 
             // Session creation uses query() instead of execute() for BigInt
             mockConnection.query.mockResolvedValueOnce([{ affectedRows: 1 }])
@@ -347,6 +348,7 @@ describe("services/navalclash/connectService", () => {
                 user_one_id: 5,
                 user_one_name: "Player1",
                 status: 0,
+                target_rival_id: null,
             }
 
             mockConnection.execute
@@ -354,8 +356,9 @@ describe("services/navalclash/connectService", () => {
                 .mockResolvedValueOnce([[mockUser]]) // find user
                 .mockResolvedValueOnce([{ affectedRows: 1 }]) // update login
                 .mockResolvedValueOnce([{ affectedRows: 0 }]) // terminate old sessions
-                .mockResolvedValueOnce([[{ game_variant: 1 }]]) // matchmaking lock SELECT FOR UPDATE
-                .mockResolvedValueOnce([[waitingSession]]) // find waiting session
+                .mockResolvedValueOnce([[{ game_variant: 1 }]]) // matchmaking lock
+                .mockResolvedValueOnce([[]]) // personal session targeting me - none
+                .mockResolvedValueOnce([[waitingSession]]) // random waiting session - found
 
             // Join session uses query() instead of execute() for BigInt
             mockConnection.query.mockResolvedValueOnce([{ affectedRows: 1 }])
@@ -402,18 +405,20 @@ describe("services/navalclash/connectService", () => {
                 .mockResolvedValueOnce([{ affectedRows: 1 }]) // update login
                 .mockResolvedValueOnce([{ affectedRows: 0 }]) // terminate
                 .mockResolvedValueOnce([[{ game_variant: 1 }]]) // lock
-                .mockResolvedValueOnce([[]]) // find waiting - none
+                .mockResolvedValueOnce([[]]) // personal targeting me - none
+                .mockResolvedValueOnce([[]]) // random waiting - none
 
             mockConnection.query.mockResolvedValueOnce([{ affectedRows: 1 }])
 
             await connect(req, mockRes)
 
-            // Find the matchmaking query (should use last_seen_one, not updated_at)
+            // Find the random matchmaking query (should use last_seen_one)
             const matchmakingCall = mockConnection.execute.mock.calls.find(
                 (call) =>
                     call[0] &&
                     call[0].includes("status = 0") &&
-                    call[0].includes("user_two_id IS NULL")
+                    call[0].includes("user_two_id IS NULL") &&
+                    call[0].includes("target_rival_id IS NULL")
             )
             expect(matchmakingCall).toBeTruthy()
             expect(matchmakingCall[0]).toContain("last_seen_one")
@@ -476,8 +481,9 @@ describe("services/navalclash/connectService", () => {
                 .mockResolvedValueOnce([{ affectedRows: 1 }]) // link user_devices
                 .mockResolvedValueOnce([{ affectedRows: 1 }]) // update last_device_id
                 .mockResolvedValueOnce([{ affectedRows: 0 }]) // terminate old sessions
-                .mockResolvedValueOnce([[{ game_variant: 1 }]]) // matchmaking lock SELECT FOR UPDATE
-                .mockResolvedValueOnce([[]]) // find waiting session
+                .mockResolvedValueOnce([[{ game_variant: 1 }]]) // matchmaking lock
+                .mockResolvedValueOnce([[]]) // personal session targeting me - none
+                .mockResolvedValueOnce([[]]) // random waiting session - none
 
             // Session creation uses query() instead of execute() for BigInt
             mockConnection.query.mockResolvedValueOnce([{ affectedRows: 1 }])
@@ -487,6 +493,343 @@ describe("services/navalclash/connectService", () => {
             expect(mockRes.json).toHaveBeenCalledWith(
                 expect.objectContaining({
                     type: "connected",
+                })
+            )
+        })
+    })
+
+    describe("personal game matchmaking (rematch)", () => {
+        const mockRes = {
+            json: jest.fn(),
+        }
+
+        const mockUser = {
+            id: 10,
+            name: "Player",
+            pin: 1234,
+            face: 0,
+            rank: 5,
+            stars: 10,
+            games: 20,
+            gameswon: 10,
+            coins: 100,
+            isbanned: 0,
+        }
+
+        /** Sets up standard execute mocks for an existing user connecting. */
+        function setupUserMocks() {
+            mockConnection.execute
+                .mockResolvedValueOnce([]) // SET TRANSACTION ISOLATION LEVEL
+                .mockResolvedValueOnce([[mockUser]]) // find user
+                .mockResolvedValueOnce([{ affectedRows: 1 }]) // update login
+                .mockResolvedValueOnce([{ affectedRows: 0 }]) // terminate old sessions
+                .mockResolvedValueOnce([[{ game_variant: 1 }]]) // matchmaking lock
+        }
+
+        beforeEach(() => {
+            mockRes.json.mockClear()
+        })
+
+        it("should join rival's personal session (mutual rematch)", async () => {
+            const req = {
+                body: {
+                    type: "connect",
+                    player: "Player",
+                    uuuid: "player-uuid",
+                    var: 1,
+                    rival: { i: 42 },
+                },
+            }
+
+            const rivalSession = {
+                id: "2000",
+                user_one_id: 42,
+                user_one_name: "Rival",
+                status: 0,
+                target_rival_id: 10, // rival is targeting us
+            }
+
+            setupUserMocks()
+            mockConnection.execute.mockResolvedValueOnce([
+                [rivalSession],
+            ]) // find rival's session
+
+            mockConnection.query.mockResolvedValueOnce([
+                { affectedRows: 1 },
+            ])
+
+            await connect(req, mockRes)
+
+            expect(mockRes.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "connected",
+                    sid: "2001", // joined as player 1
+                })
+            )
+        })
+
+        it("should join rival's random session (personal targets random)", async () => {
+            const req = {
+                body: {
+                    type: "connect",
+                    player: "Player",
+                    uuuid: "player-uuid",
+                    var: 1,
+                    rival: { i: 42 },
+                },
+            }
+
+            const rivalRandomSession = {
+                id: "3000",
+                user_one_id: 42,
+                user_one_name: "Rival",
+                status: 0,
+                target_rival_id: null, // rival is waiting for anyone
+            }
+
+            setupUserMocks()
+            mockConnection.execute.mockResolvedValueOnce([
+                [rivalRandomSession],
+            ]) // find rival's session
+
+            mockConnection.query.mockResolvedValueOnce([
+                { affectedRows: 1 },
+            ])
+
+            await connect(req, mockRes)
+
+            expect(mockRes.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "connected",
+                    sid: "3001",
+                })
+            )
+        })
+
+        it("should create personal session when rival is not waiting", async () => {
+            const req = {
+                body: {
+                    type: "connect",
+                    player: "Player",
+                    uuuid: "player-uuid",
+                    var: 1,
+                    rival: { i: 42 },
+                },
+            }
+
+            setupUserMocks()
+            mockConnection.execute.mockResolvedValueOnce([
+                [],
+            ]) // rival not waiting
+
+            mockConnection.query.mockResolvedValueOnce([
+                { affectedRows: 1 },
+            ])
+
+            await connect(req, mockRes)
+
+            expect(mockRes.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "connected",
+                    sid: expect.any(String),
+                })
+            )
+            // Verify session was created with target_rival_id
+            const insertCall = mockConnection.query.mock.calls[0]
+            expect(insertCall[0]).toContain("target_rival_id")
+            expect(insertCall[1]).toContain(42)
+        })
+
+        it("should not join rival's session targeting someone else", async () => {
+            const req = {
+                body: {
+                    type: "connect",
+                    player: "Player",
+                    uuuid: "player-uuid",
+                    var: 1,
+                    rival: { i: 42 },
+                },
+            }
+
+            // Rival has a session but targeting user 99, not us (10).
+            // The query uses (target_rival_id IS NULL OR target_rival_id = ?),
+            // so this session would NOT be returned by the DB.
+            setupUserMocks()
+            mockConnection.execute.mockResolvedValueOnce([
+                [],
+            ]) // find rival's session - none matching
+
+            mockConnection.query.mockResolvedValueOnce([
+                { affectedRows: 1 },
+            ])
+
+            await connect(req, mockRes)
+
+            // Should create new personal session, not join
+            expect(mockRes.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "connected",
+                    sid: expect.any(String),
+                })
+            )
+            const insertCall = mockConnection.query.mock.calls[0]
+            expect(insertCall[0]).toContain("INSERT INTO game_sessions")
+        })
+
+        it("should pull random player into personal session targeting them", async () => {
+            const req = {
+                body: {
+                    type: "connect",
+                    player: "Player",
+                    uuuid: "player-uuid",
+                    var: 1,
+                    // No rival - random game
+                },
+            }
+
+            const personalForMe = {
+                id: "4000",
+                user_one_id: 42,
+                user_one_name: "SomeoneWaitingForMe",
+                status: 0,
+                target_rival_id: 10, // targeting our user ID
+            }
+
+            setupUserMocks()
+            mockConnection.execute.mockResolvedValueOnce([
+                [personalForMe],
+            ]) // personal session targeting me - found!
+
+            mockConnection.query.mockResolvedValueOnce([
+                { affectedRows: 1 },
+            ])
+
+            await connect(req, mockRes)
+
+            expect(mockRes.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "connected",
+                    sid: "4001",
+                })
+            )
+        })
+
+        it("should exclude personal sessions from random matchmaking", async () => {
+            const req = {
+                body: {
+                    type: "connect",
+                    player: "Player",
+                    uuuid: "player-uuid",
+                    var: 1,
+                },
+            }
+
+            setupUserMocks()
+            mockConnection.execute
+                .mockResolvedValueOnce([[]]) // personal targeting me - none
+                .mockResolvedValueOnce([[]]) // random waiting - none
+
+            mockConnection.query.mockResolvedValueOnce([
+                { affectedRows: 1 },
+            ])
+
+            await connect(req, mockRes)
+
+            // Find the random matchmaking query and verify it excludes personal sessions
+            const randomQuery = mockConnection.execute.mock.calls.find(
+                (call) =>
+                    call[0] &&
+                    call[0].includes("target_rival_id IS NULL") &&
+                    call[0].includes("user_one_id != ?")
+            )
+            expect(randomQuery).toBeTruthy()
+            expect(randomQuery[0]).toContain("target_rival_id IS NULL")
+        })
+
+        it("should match agent to personal session targeting it (agent rematch)", async () => {
+            const req = {
+                body: {
+                    type: "connect",
+                    player: "AgentBot",
+                    uuuid: "agent-uuid",
+                    var: 1,
+                    v: 2100, // agent version
+                },
+            }
+
+            const agentUser = {
+                ...mockUser,
+                id: 99,
+                name: "AgentBot",
+            }
+
+            const personalForAgent = {
+                id: "5000",
+                user_one_id: 10,
+                user_one_name: "HumanPlayer",
+                status: 0,
+                target_rival_id: 99, // human targeting this agent
+            }
+
+            mockConnection.execute
+                .mockResolvedValueOnce([]) // SET TRANSACTION ISOLATION LEVEL
+                .mockResolvedValueOnce([[agentUser]]) // find user
+                .mockResolvedValueOnce([{ affectedRows: 1 }]) // update login
+                .mockResolvedValueOnce([{ affectedRows: 0 }]) // terminate
+                .mockResolvedValueOnce([[{ game_variant: 1 }]]) // lock
+                .mockResolvedValueOnce([[personalForAgent]]) // personal targeting agent
+
+            mockConnection.query.mockResolvedValueOnce([
+                { affectedRows: 1 },
+            ])
+
+            await connect(req, mockRes)
+
+            // Agent should join the personal session targeting it
+            expect(mockRes.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "connected",
+                    sid: "5001",
+                })
+            )
+        })
+
+        it("should let human rematch a specific agent", async () => {
+            const req = {
+                body: {
+                    type: "connect",
+                    player: "HumanPlayer",
+                    uuuid: "human-uuid",
+                    var: 1,
+                    rival: { i: 99 }, // targeting specific agent
+                },
+            }
+
+            const agentSession = {
+                id: "6000",
+                user_one_id: 99,
+                user_one_name: "AgentBot",
+                status: 0,
+                target_rival_id: null, // agent waiting for anyone
+                version_one: 2100,
+            }
+
+            setupUserMocks()
+            mockConnection.execute.mockResolvedValueOnce([
+                [agentSession],
+            ]) // found agent's session
+
+            mockConnection.query.mockResolvedValueOnce([
+                { affectedRows: 1 },
+            ])
+
+            await connect(req, mockRes)
+
+            // Human should join agent's session directly
+            expect(mockRes.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "connected",
+                    sid: "6001",
                 })
             )
         })

--- a/services/navalclash/connectService.test.js
+++ b/services/navalclash/connectService.test.js
@@ -266,7 +266,7 @@ describe("services/navalclash/connectService", () => {
             })
         })
 
-        it("should create new session for new player", async () => {
+        it("should create new session with last_seen_one", async () => {
             const req = {
                 body: {
                     type: "connect",
@@ -312,11 +312,14 @@ describe("services/navalclash/connectService", () => {
                     u: expect.objectContaining({ n: "NewPlayer" }),
                 })
             )
+            // Verify session INSERT includes last_seen_one
+            const insertCall = mockConnection.query.mock.calls[0]
+            expect(insertCall[0]).toContain("last_seen_one")
             expect(mockConnection.commit).toHaveBeenCalled()
             expect(mockConnection.release).toHaveBeenCalled()
         })
 
-        it("should join existing session when waiting session found", async () => {
+        it("should join existing session with last_seen_two", async () => {
             const req = {
                 body: {
                     type: "connect",
@@ -364,6 +367,59 @@ describe("services/navalclash/connectService", () => {
                     type: "connected",
                     sid: "1001", // Base 1000 + 1 for player 1
                 })
+            )
+            // Verify session UPDATE includes last_seen_two
+            const updateCall = mockConnection.query.mock.calls[0]
+            expect(updateCall[0]).toContain("last_seen_two")
+        })
+
+        it("should use last_seen_one for matchmaking staleness check", async () => {
+            const req = {
+                body: {
+                    type: "connect",
+                    player: "TestPlayer",
+                    uuuid: "test-uuid",
+                    var: 1,
+                },
+            }
+
+            const mockUser = {
+                id: 10,
+                name: "TestPlayer",
+                pin: 1234,
+                face: 0,
+                rank: 0,
+                stars: 0,
+                games: 0,
+                gameswon: 0,
+                coins: 0,
+                isbanned: 0,
+            }
+
+            mockConnection.execute
+                .mockResolvedValueOnce([]) // SET TRANSACTION ISOLATION LEVEL
+                .mockResolvedValueOnce([[mockUser]]) // find user
+                .mockResolvedValueOnce([{ affectedRows: 1 }]) // update login
+                .mockResolvedValueOnce([{ affectedRows: 0 }]) // terminate
+                .mockResolvedValueOnce([[{ game_variant: 1 }]]) // lock
+                .mockResolvedValueOnce([[]]) // find waiting - none
+
+            mockConnection.query.mockResolvedValueOnce([{ affectedRows: 1 }])
+
+            await connect(req, mockRes)
+
+            // Find the matchmaking query (should use last_seen_one, not updated_at)
+            const matchmakingCall = mockConnection.execute.mock.calls.find(
+                (call) =>
+                    call[0] &&
+                    call[0].includes("status = 0") &&
+                    call[0].includes("user_two_id IS NULL")
+            )
+            expect(matchmakingCall).toBeTruthy()
+            expect(matchmakingCall[0]).toContain("last_seen_one")
+            expect(matchmakingCall[0]).toContain("INTERVAL 45 SECOND")
+            expect(matchmakingCall[0]).not.toContain(
+                "updated_at > DATE_SUB"
             )
         })
 

--- a/services/navalclash/constants.js
+++ b/services/navalclash/constants.js
@@ -1,0 +1,303 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ *
+ * Centralized constants for the Naval Clash backend.
+ * All game-related constants should be defined here.
+ */
+
+// =============================================================================
+// INFO MESSAGE CONSTANTS (MSG_*)
+// These match InfoMessage.java in the client
+// =============================================================================
+
+const MSG = {
+    // Basic messages (1-10)
+    WELCOME: 1,
+    HURRY_UP: 2,
+    USER_READY: 3,
+    LAST_CONNECT: 4,
+    LEFT_SCREEN: 5,
+    ANY_TEXT: 6,
+    USER_SETUP: 7,
+    CHAT: 8,
+    USER_BANNED: 9,
+    USER_CHEATED: 10,
+
+    // System messages (11-17)
+    MAINTENANCE: 11,
+    NEW_VERSION: 12,
+    OLD_VERSION: 13, // Warning: version is old but allowed
+    OLD_FORBIDDEN_VERSION: 14, // Error: version too old, must update
+    PUNISHMENT: 15,
+    PAUSED_GAME: 16,
+    RESUMED_GAME: 17,
+
+    // Personal rival messages (26-31)
+    PERSONAL_RIVAL_SETUP: 26, // Rival is setting up ships
+    PERSONAL_RIVAL_PLAYING: 27, // Rival is currently playing
+    PERSONAL_RIVAL_REQUEST: 28, // Personal game invitation request
+    PERSONAL_RIVAL_REJECTED: 29, // Invitation rejected
+    PERSONAL_RIVAL_FINISHED_GAME: 30, // Rival finished their game
+    PERSONAL_RIVAL_ACCEPTED: 31, // Invitation accepted
+
+    // Error messages (40-41)
+    ERROR_NO_INET: 40,
+    COMMUNICATION_ERR: 41,
+}
+
+// =============================================================================
+// SESSION STATUS CONSTANTS
+// Game session lifecycle states stored in game_sessions.status
+// =============================================================================
+
+const SESSION_STATUS = {
+    WAITING: 0, // Waiting for second player
+    IN_PROGRESS: 1, // Both players connected, game in progress
+
+    // Finished states (2-12)
+    FINISHED_TERMINATED_WAITING: 2, // Waiting session terminated (player left)
+    FINISHED_SURRENDERED_AUTO: 3, // Auto-surrender (opponent disconnected)
+    FINISHED_SURRENDERED: 4, // Player surrendered
+    FINISHED_TIMED_OUT_WAITING: 5, // Waiting session timed out
+    FINISHED_TIMED_OUT_PLAYING: 6, // Playing session timed out
+    FINISHED_TERMINATED_DUPLICATE: 7, // Terminated due to user reconnecting
+    FINISHED_LEFT_OLD: 8, // Old session left
+    FINISHED_NOT_PINGABLE: 9, // Session not pingable
+    FINISHED_OK: 10, // Game finished normally
+    FINISHED_SLEEP_CHEATER: 11, // Sleep cheater detected
+    FINISHED_TIMED_BANNED: 12, // Banned for timeout
+}
+
+// =============================================================================
+// USER STATUS CONSTANTS
+// User presence/activity states stored in users.status
+// =============================================================================
+
+const USER_STATUS = {
+    IDLE: 0, // In menus, not actively playing
+    SETUP: 1, // Setting up ships (field editor)
+    PLAYING: 2, // In active game
+}
+
+// =============================================================================
+// GAME TYPE CONSTANTS
+// Stored in game_sessions.game_type
+// =============================================================================
+
+const GAME_TYPE = {
+    RANDOM: 0, // Random matchmaking
+    PERSONAL: 1, // Personal game (invited rival)
+}
+
+// =============================================================================
+// LIST TYPE CONSTANTS
+// For user lists (friends/blocked) in userlists.list_type
+// =============================================================================
+
+const LIST_TYPE = {
+    FRIENDS: 1, // Friends/saved rivals
+    BLOCKED: 2, // Blocked/rejected users
+}
+
+// =============================================================================
+// RIVAL INFO TYPE CONSTANTS
+// Used in social API responses to identify rival source
+// Must match RivalInfo.java in client
+// =============================================================================
+
+const RIVAL_TYPE = {
+    SEARCH: 1, // From search results
+    RECENT: 2, // From recent opponents
+    SAVED: 3, // From friends list
+    REJECTED: 4, // From blocked list
+}
+
+// =============================================================================
+// BONUS TYPE CONSTANTS
+// Game result bonus types for calculateBonus()
+// =============================================================================
+
+const BONUS_TYPE = {
+    WIN_BONUS: 0, // Normal win
+    LOST_BONUS: 1, // Normal loss
+    SURRENDER_WIN_BONUS: 2, // Won by opponent surrender
+    SURRENDER_LOST_BONUS: 3, // Lost by surrender
+    INTERRUPT_WIN_BONUS: 4, // Won by opponent disconnect
+    INTERRUPT_LOST_BONUS: 5, // Lost by disconnect
+    // Index 6 is unused
+    LOST_BONUS_WITH_WEAPONS: 7, // Lost but used weapons
+}
+
+// =============================================================================
+// WEAPON CONSTANTS
+// Weapon codes, IDs, and names
+// =============================================================================
+
+// Weapon code to inventory item ID mapping
+// Supports both short codes (wmn, dch) and full names (mine, dutch)
+const WEAPON_CODE_TO_ID = {
+    wmn: "0", // Mine
+    mine: "0",
+    dch: "1", // Dutch (water bombs)
+    dutch: "1",
+    anr: "2", // Radar
+    radar: "2",
+    smw: "3", // Shuffle/Ship Move
+    shuffle: "3",
+    sth: "4", // Stealth
+    stealth: "4",
+    csh: "5", // Chain Shield
+    cls: "5", // Classic Shield (alias)
+    cshield: "5",
+}
+
+// Weapon ID to name mapping
+const WEAPON_ID_TO_NAME = {
+    0: "mine",
+    1: "dutch",
+    2: "radar",
+    3: "shuffle",
+    4: "stealth",
+    5: "cshield",
+}
+
+// Weapon names array (index = weapon ID)
+const WEAPON_NAMES = ["mine", "dutch", "radar", "shuffle", "stealth", "cshield"]
+
+// =============================================================================
+// BUY/SHOP ERROR CONSTANTS
+// Error codes for shop purchase operations
+// =============================================================================
+
+const BUY_ERROR = {
+    SUCCESS: 0,
+    WRONG_PRICE: 3,
+    DENIED: -1,
+}
+
+// =============================================================================
+// VERSION CONSTANTS
+// Client version thresholds for feature detection
+// =============================================================================
+
+const VERSION = {
+    // AI agent version range (2100-2200)
+    // Agents can only play vs humans, not other agents
+    AGENT_MIN: 2100,
+    AGENT_MAX: 2200,
+
+    // Minimum version for paid/premium features
+    PAID_MIN: 2000,
+
+    // Minimum version to include topstars in leaderboard response
+    TOPSTARS_MIN: 30,
+}
+
+// =============================================================================
+// RANK CONSTANTS
+// Rank calculation thresholds and coin rewards
+// =============================================================================
+
+// Base coins for winning a game
+const BASE_WIN_COINS = 9
+
+// Maximum rank difference for bonus calculation
+const MAX_RANK_DELTA = 5
+
+// Star thresholds for each rank (paid version)
+// Index = rank level, value = minimum stars required
+const RANK_THRESHOLDS_PAID = [
+    0, // Rank 0: 0 stars
+    0, // Rank 1: 0 stars (starting rank)
+    20, // Rank 2: 20 stars
+    80, // Rank 3: 80 stars
+    200, // Rank 4: 200 stars
+    400, // Rank 5: 400 stars
+    700, // Rank 6: 700 stars
+    1100, // Rank 7: 1100 stars
+    1600, // Rank 8: 1600 stars
+    2300, // Rank 9: 2300 stars
+    3200, // Rank 10: 3200 stars
+]
+
+// Star thresholds for each rank (free version - more lenient)
+const RANK_THRESHOLDS_FREE = [
+    0, 0, 10, 30, 60, 100, 200, 350, 600, 900, 1400,
+]
+
+// Default rank thresholds (use paid version)
+const RANK_THRESHOLDS = RANK_THRESHOLDS_PAID
+
+// =============================================================================
+// TIMING CONSTANTS
+// Various timeout and cache duration values
+// =============================================================================
+
+const TIMING = {
+    // Long polling timeout for /receive endpoint (30 seconds)
+    POLL_TIMEOUT_MS: 30000,
+
+    // Config cache TTL (1 hour)
+    CACHE_TTL_MS: 60 * 60 * 1000,
+
+    // Session considered stale after this time (2 minutes)
+    SESSION_STALE_MS: 2 * 60 * 1000,
+
+    // Rival status considered "red" (disconnected) after 11 seconds
+    RIVAL_RED_TIME_MS: 11000,
+}
+
+// =============================================================================
+// FIELD ENCODING CONSTANTS
+// For battlefield encoding/decoding
+// =============================================================================
+
+const FIELD = {
+    // Shift value for field encoding
+    SHIFT_VAL: 5,
+}
+
+// =============================================================================
+// EXPORTS
+// =============================================================================
+
+module.exports = {
+    // Message constants
+    MSG,
+
+    // Session and game state
+    SESSION_STATUS,
+    USER_STATUS,
+    GAME_TYPE,
+
+    // Social features
+    LIST_TYPE,
+    RIVAL_TYPE,
+
+    // Game mechanics
+    BONUS_TYPE,
+    BASE_WIN_COINS,
+    MAX_RANK_DELTA,
+    RANK_THRESHOLDS,
+    RANK_THRESHOLDS_PAID,
+    RANK_THRESHOLDS_FREE,
+
+    // Weapons
+    WEAPON_CODE_TO_ID,
+    WEAPON_ID_TO_NAME,
+    WEAPON_NAMES,
+
+    // Shop
+    BUY_ERROR,
+
+    // Versions
+    VERSION,
+
+    // Timing
+    TIMING,
+
+    // Field encoding
+    FIELD,
+}

--- a/services/navalclash/constants.js
+++ b/services/navalclash/constants.js
@@ -234,8 +234,8 @@ const RANK_THRESHOLDS = RANK_THRESHOLDS_PAID
 // =============================================================================
 
 const TIMING = {
-    // Long polling timeout for /receive endpoint (30 seconds)
-    POLL_TIMEOUT_MS: 30000,
+    // Long polling timeout for /receive endpoint (20 seconds)
+    POLL_TIMEOUT_MS: 20000,
 
     // Config cache TTL (1 hour)
     CACHE_TTL_MS: 60 * 60 * 1000,
@@ -245,6 +245,17 @@ const TIMING = {
 
     // Rival status considered "red" (disconnected) after 11 seconds
     RIVAL_RED_TIME_MS: 11000,
+
+    // Player considered alive if last_seen within this threshold (45 seconds)
+    // Used for: matchmaking filter, dead-opponent detection during poll
+    SESSION_ALIVE_MS: 45 * 1000,
+
+    // Session purged by background job after this time (120 seconds)
+    // Applies to both WAITING and IN_PROGRESS sessions
+    SESSION_PURGE_MS: 120 * 1000,
+
+    // Background purge job interval (60 seconds)
+    SESSION_PURGE_INTERVAL_MS: 60 * 1000,
 }
 
 // =============================================================================

--- a/services/navalclash/constants.js
+++ b/services/navalclash/constants.js
@@ -234,8 +234,8 @@ const RANK_THRESHOLDS = RANK_THRESHOLDS_PAID
 // =============================================================================
 
 const TIMING = {
-    // Long polling timeout for /receive endpoint (20 seconds)
-    POLL_TIMEOUT_MS: 20000,
+    // Long polling timeout for /receive endpoint (15 seconds)
+    POLL_TIMEOUT_MS: 15000,
 
     // Config cache TTL (1 hour)
     CACHE_TTL_MS: 60 * 60 * 1000,
@@ -246,9 +246,9 @@ const TIMING = {
     // Rival status considered "red" (disconnected) after 11 seconds
     RIVAL_RED_TIME_MS: 11000,
 
-    // Player considered alive if last_seen within this threshold (45 seconds)
+    // Player considered alive if last_seen within this threshold (55 seconds)
     // Used for: matchmaking filter, dead-opponent detection during poll
-    SESSION_ALIVE_MS: 45 * 1000,
+    SESSION_ALIVE_MS: 55 * 1000,
 
     // Session purged by background job after this time (120 seconds)
     // Applies to both WAITING and IN_PROGRESS sessions

--- a/services/navalclash/constants.js
+++ b/services/navalclash/constants.js
@@ -223,9 +223,7 @@ const RANK_THRESHOLDS_PAID = [
 ]
 
 // Star thresholds for each rank (free version - more lenient)
-const RANK_THRESHOLDS_FREE = [
-    0, 0, 10, 30, 60, 100, 200, 350, 600, 900, 1400,
-]
+const RANK_THRESHOLDS_FREE = [0, 0, 10, 30, 60, 100, 200, 350, 600, 900, 1400]
 
 // Default rank thresholds (use paid version)
 const RANK_THRESHOLDS = RANK_THRESHOLDS_PAID

--- a/services/navalclash/gameService.js
+++ b/services/navalclash/gameService.js
@@ -1402,7 +1402,10 @@ async function weaponsList(req, res) {
     const { sid, weap } = req.body
     const ctx = { reqId: req.requestId, sid }
 
-    logger.debug({ ...ctx, weapCount: weap?.length || 0 }, "Weapon list request")
+    logger.debug(
+        { ...ctx, weapCount: weap?.length || 0 },
+        "Weapon list request"
+    )
 
     const session = validateSession(sid, res, ctx)
     if (!session) return

--- a/services/navalclash/gameService.js
+++ b/services/navalclash/gameService.js
@@ -16,6 +16,7 @@ const { logger } = require("../../utils/logger")
 const {
     validateWeaponPlacement,
     trackWeaponPlacement,
+    countWeaponsByType,
     trackRadarUsage,
     trackShuffleUsage,
     consumeLoserWeapons,
@@ -651,6 +652,25 @@ async function fieldInfo(req, res) {
             errcode: 5,
             reason: "Session not found",
         })
+    }
+
+    // Extract weapons from field data and track them for consumption at game end.
+    // The client embeds weapons in fldinfo.json.weap (Dutch, mines, stealth, etc.)
+    // rather than sending a separate /wpl for initial placement.
+    if (json.weap && Array.isArray(json.weap) && json.weap.length > 0) {
+        const weaponCounts = countWeaponsByType(json.weap)
+        if (Object.keys(weaponCounts).length > 0) {
+            await trackWeaponPlacement(
+                session.baseSessionId,
+                session.player,
+                weaponCounts,
+                ctx
+            )
+            logger.debug(
+                { ...ctx, player: session.player, weaponCounts },
+                "Weapons extracted from fldinfo and tracked"
+            )
+        }
     }
 
     // Get both players' ranks to calculate bonus values

--- a/services/navalclash/gameService.js
+++ b/services/navalclash/gameService.js
@@ -1163,6 +1163,7 @@ async function finish(req, res) {
         const isFirstFinish = updateResult.affectedRows > 0
         let winnerCoins = 0
         let loserCoins = 0
+        let pendingScore = null
 
         if (isFirstFinish) {
             // This request "won" the race - apply stats and coins
@@ -1222,29 +1223,19 @@ async function finish(req, res) {
                 ctx
             )
 
-            // Submit score to leaderboard if winner provided score data
-            // Score is only recorded if:
-            // - Player won
-            // - Score > threshold (3000)
-            // - Game time >= 30 seconds
-            // - Not a duplicate
+            // Capture score data for post-commit submission.
+            // submitScore() uses pool.execute() (separate connections),
+            // so calling it inside the transaction causes lock contention
+            // with the concurrent loser's finish request.
             if (won && sc && sc.score) {
-                const scoreResult = await submitScore(
+                pendingScore = {
                     winnerId,
                     loserId,
-                    sc.score,
-                    sc.time || 0,
-                    3, // game_type: 3 = web
-                    gameSession.game_variant || 1,
+                    score: sc.score,
+                    time: sc.time || 0,
+                    gameVariant: gameSession.game_variant || 1,
                     winnerRank,
                     loserRank,
-                    ctx
-                )
-                if (scoreResult.success) {
-                    logger.info(
-                        { ...ctx, scoreId: scoreResult.scoreId, score: sc.score },
-                        "Score recorded to leaderboard"
-                    )
                 }
             }
         } else {
@@ -1289,6 +1280,31 @@ async function finish(req, res) {
         )
 
         await conn.commit()
+
+        // Submit score after commit to avoid holding transaction locks
+        if (pendingScore) {
+            const scoreResult = await submitScore(
+                pendingScore.winnerId,
+                pendingScore.loserId,
+                pendingScore.score,
+                pendingScore.time,
+                3, // game_type: 3 = web
+                pendingScore.gameVariant,
+                pendingScore.winnerRank,
+                pendingScore.loserRank,
+                ctx
+            )
+            if (scoreResult.success) {
+                logger.info(
+                    {
+                        ...ctx,
+                        scoreId: scoreResult.scoreId,
+                        score: pendingScore.score,
+                    },
+                    "Score recorded to leaderboard"
+                )
+            }
+        }
 
         // Finalize training data after transaction commit (only for first finish)
         if (isFirstFinish) {

--- a/services/navalclash/gameService.test.js
+++ b/services/navalclash/gameService.test.js
@@ -18,8 +18,9 @@ jest.mock("../../db/navalclash", () => ({
         getConnection: jest.fn(),
     },
     SESSION_STATUS: {
-        IN_PROGRESS: 0,
-        FINISHED_OK: 1,
+        WAITING: 0,
+        IN_PROGRESS: 1,
+        FINISHED_OK: 10,
         FINISHED_TERMINATED_WAITING: 2,
         FINISHED_SURRENDERED_AUTO: 3,
         FINISHED_SURRENDERED: 4,
@@ -56,6 +57,17 @@ const {
     shipMove,
     validateSession,
     determineWinnerLoser,
+    BONUS_TYPE,
+    calculateWinBonus,
+    calculateBonusCoins,
+    clamp,
+    buildBonusObject,
+    PAID_VERSION_MIN,
+    RANK_THRESHOLDS,
+    RANK_THRESHOLDS_PAID,
+    RANK_THRESHOLDS_FREE,
+    calculateRank,
+    val2mess,
 } = require("./gameService")
 
 const { sendMessage } = require("./messageService")
@@ -64,6 +76,313 @@ describe("services/navalclash/gameService", () => {
     beforeEach(() => {
         jest.clearAllMocks()
         pool.getConnection.mockResolvedValue(mockConnection)
+    })
+
+    describe("clamp", () => {
+        it("should return value if within range", () => {
+            expect(clamp(5, 0, 10)).toBe(5)
+        })
+
+        it("should return min if value below range", () => {
+            expect(clamp(-5, 0, 10)).toBe(0)
+        })
+
+        it("should return max if value above range", () => {
+            expect(clamp(15, 0, 10)).toBe(10)
+        })
+    })
+
+    describe("val2mess", () => {
+        it("should encode 0 correctly", () => {
+            // Known value from Java: val2mess(0) should produce a specific encoded value
+            const encoded = val2mess(0)
+            expect(typeof encoded).toBe("number")
+            expect(encoded).toBeGreaterThan(0) // Encoded 0 should not be 0
+        })
+
+        it("should encode positive values", () => {
+            const encoded = val2mess(100)
+            expect(typeof encoded).toBe("number")
+            expect(encoded).not.toBe(100) // Should be different from input
+        })
+
+        it("should handle negative values", () => {
+            const encoded = val2mess(-5)
+            expect(typeof encoded).toBe("number")
+            // Negative values have LSB set to 1
+            expect(encoded & 1).toBe(1)
+        })
+
+        it("should encode different values to different results", () => {
+            const encoded0 = val2mess(0)
+            const encoded1 = val2mess(1)
+            const encoded100 = val2mess(100)
+            expect(encoded0).not.toBe(encoded1)
+            expect(encoded1).not.toBe(encoded100)
+        })
+    })
+
+    describe("calculateWinBonus", () => {
+        it("should return base bonus (9) when ranks are equal", () => {
+            expect(calculateWinBonus(5, 5)).toBe(9)
+        })
+
+        it("should add rank difference when beating higher ranked opponent", () => {
+            // Winner rank 2, opponent rank 6 -> 9 + (6-2) = 13
+            expect(calculateWinBonus(2, 6)).toBe(13)
+        })
+
+        it("should subtract rank difference when beating lower ranked opponent", () => {
+            // Winner rank 6, opponent rank 2 -> 9 + (2-6) = 5
+            expect(calculateWinBonus(6, 2)).toBe(5)
+        })
+
+        it("should cap positive rank difference at +5", () => {
+            // Winner rank 1, opponent rank 10 -> 9 + 5 (capped) = 14
+            expect(calculateWinBonus(1, 10)).toBe(14)
+        })
+
+        it("should cap negative rank difference at -5", () => {
+            // Winner rank 10, opponent rank 1 -> 9 + (-5) (capped) = 4
+            expect(calculateWinBonus(10, 1)).toBe(4)
+        })
+    })
+
+    describe("calculateBonusCoins", () => {
+        it("should return correct coins for WIN_BONUS", () => {
+            expect(calculateBonusCoins(BONUS_TYPE.WIN_BONUS, 3, 5)).toBe(11) // 9 + 2
+        })
+
+        it("should return -1 for LOST_BONUS", () => {
+            expect(calculateBonusCoins(BONUS_TYPE.LOST_BONUS)).toBe(-1)
+        })
+
+        it("should return half of win bonus for SURRENDER_WIN_BONUS", () => {
+            // Win bonus would be 13, half is 6
+            expect(calculateBonusCoins(BONUS_TYPE.SURRENDER_WIN_BONUS, 2, 6)).toBe(6)
+        })
+
+        it("should return at least 1 for SURRENDER_WIN_BONUS", () => {
+            // Win bonus would be 4, half is 2, so return 2
+            expect(calculateBonusCoins(BONUS_TYPE.SURRENDER_WIN_BONUS, 10, 1)).toBe(2)
+            // Even with very low bonus, minimum is 1
+            expect(calculateBonusCoins(BONUS_TYPE.SURRENDER_WIN_BONUS, 5, 5)).toBe(4) // 9/2 = 4
+        })
+
+        it("should return -2 for SURRENDER_LOST_BONUS", () => {
+            expect(calculateBonusCoins(BONUS_TYPE.SURRENDER_LOST_BONUS)).toBe(-2)
+        })
+
+        it("should return 1 for INTERRUPT_WIN_BONUS", () => {
+            expect(calculateBonusCoins(BONUS_TYPE.INTERRUPT_WIN_BONUS)).toBe(1)
+        })
+
+        it("should return 0 for INTERRUPT_LOST_BONUS", () => {
+            expect(calculateBonusCoins(BONUS_TYPE.INTERRUPT_LOST_BONUS)).toBe(0)
+        })
+
+        it("should return +2 for LOST_BONUS_WITH_WEAPONS", () => {
+            expect(calculateBonusCoins(BONUS_TYPE.LOST_BONUS_WITH_WEAPONS)).toBe(2)
+        })
+
+        it("should return 0 for unknown bonus type", () => {
+            expect(calculateBonusCoins(99)).toBe(0)
+        })
+    })
+
+    describe("buildBonusObject", () => {
+        it("should return correct structure with type bns", () => {
+            const result = buildBonusObject(5, 5)
+            expect(result.type).toBe("bns")
+            expect(result.gbc).toHaveLength(8)
+            expect(result.gbs).toHaveLength(8)
+        })
+
+        it("should calculate and encode gbc values for equal ranks", () => {
+            const result = buildBonusObject(5, 5)
+            // gbc indices: 0=WIN, 1=LOST, 2=SURR_WIN, 3=SURR_LOST, 4=INT_WIN, 5=INT_LOST, 6=unused, 7=LOST_WEAPONS
+            // All values are encoded with val2mess()
+            expect(result.gbc[0]).toBe(val2mess(9)) // WIN: 9 + 0
+            expect(result.gbc[1]).toBe(val2mess(-1)) // LOST: -1
+            expect(result.gbc[2]).toBe(val2mess(4)) // SURR_WIN: floor(9/2) = 4
+            expect(result.gbc[3]).toBe(val2mess(-2)) // SURR_LOST: -2
+            expect(result.gbc[4]).toBe(val2mess(1)) // INT_WIN: 1
+            expect(result.gbc[5]).toBe(val2mess(0)) // INT_LOST: 0
+            expect(result.gbc[6]).toBe(val2mess(0)) // unused
+            expect(result.gbc[7]).toBe(val2mess(2)) // LOST_WEAPONS: +2
+        })
+
+        it("should calculate and encode gbc values when beating higher ranked opponent", () => {
+            // myRank=2, opponentRank=7 -> delta = +5 (capped)
+            const result = buildBonusObject(2, 7)
+            expect(result.gbc[0]).toBe(val2mess(14)) // WIN: 9 + 5
+            expect(result.gbc[2]).toBe(val2mess(7)) // SURR_WIN: floor(14/2) = 7
+        })
+
+        it("should calculate and encode gbc values when beating lower ranked opponent", () => {
+            // myRank=8, opponentRank=3 -> delta = -5 (capped)
+            const result = buildBonusObject(8, 3)
+            expect(result.gbc[0]).toBe(val2mess(4)) // WIN: 9 + (-5)
+            expect(result.gbc[2]).toBe(val2mess(2)) // SURR_WIN: floor(4/2) = 2
+        })
+
+        it("should encode gbs array with opponent rank + 1 for win", () => {
+            const result = buildBonusObject(3, 7)
+            // gbs[0] = opponent_rank + 1 (stars for winning), all encoded
+            expect(result.gbs[0]).toBe(val2mess(8)) // 7 + 1
+            expect(result.gbs[1]).toBe(val2mess(0)) // LOST
+            expect(result.gbs[2]).toBe(val2mess(1)) // SURR_WIN
+            expect(result.gbs[3]).toBe(val2mess(0)) // SURR_LOST
+            expect(result.gbs[4]).toBe(val2mess(1)) // INT_WIN
+            expect(result.gbs[5]).toBe(val2mess(0)) // INT_LOST
+            expect(result.gbs[6]).toBe(val2mess(0)) // unused
+            expect(result.gbs[7]).toBe(val2mess(0)) // LOST_WEAPONS
+        })
+    })
+
+    describe("calculateRank", () => {
+        describe("paid version (v >= 2000)", () => {
+            it("should return rank 0 (Ensign) for 0 stars", () => {
+                expect(calculateRank(0, 2000)).toBe(0)
+            })
+
+            it("should return rank 0 (Ensign) for 9 stars", () => {
+                expect(calculateRank(9, 2000)).toBe(0)
+            })
+
+            it("should return rank 1 (Lieutenant) for 10 stars", () => {
+                expect(calculateRank(10, 2000)).toBe(1)
+            })
+
+            it("should return rank 2 (Lieutenant Commander) for 50 stars", () => {
+                expect(calculateRank(50, 2000)).toBe(2)
+            })
+
+            it("should return rank 3 (Commander) for 100 stars", () => {
+                expect(calculateRank(100, 2000)).toBe(3)
+            })
+
+            it("should return rank 4 (Captain) for 200 stars", () => {
+                expect(calculateRank(200, 2000)).toBe(4)
+            })
+
+            it("should return rank 5 (Rear Admiral) for 500 stars", () => {
+                expect(calculateRank(500, 2000)).toBe(5)
+            })
+
+            it("should return rank 6 (Admiral) for 1000 stars", () => {
+                expect(calculateRank(1000, 2000)).toBe(6)
+            })
+
+            it("should return rank 7 (Fleet Admiral) for 3000 stars", () => {
+                expect(calculateRank(3000, 2000)).toBe(7)
+            })
+
+            it("should return rank 8 (Honored Fleet Admiral) for 50000 stars", () => {
+                expect(calculateRank(50000, 2000)).toBe(8)
+            })
+
+            it("should handle boundary values correctly", () => {
+                expect(calculateRank(49, 2000)).toBe(1) // just below Lieutenant Commander
+                expect(calculateRank(51, 2000)).toBe(2) // just above Lieutenant Commander
+                expect(calculateRank(999, 2000)).toBe(5) // just below Admiral
+                expect(calculateRank(1001, 2000)).toBe(6) // just above Admiral
+            })
+
+            it("should return highest rank for very high stars", () => {
+                expect(calculateRank(100000, 2000)).toBe(8)
+                expect(calculateRank(1000000, 2000)).toBe(8)
+            })
+
+            it("should default to paid version when no version specified", () => {
+                expect(calculateRank(1000)).toBe(6) // Admiral in paid version
+            })
+        })
+
+        describe("free version (v < 2000)", () => {
+            it("should return rank 0 (Seaman) for 0 stars", () => {
+                expect(calculateRank(0, 1999)).toBe(0)
+            })
+
+            it("should return rank 0 (Seaman) for 9 stars", () => {
+                expect(calculateRank(9, 1999)).toBe(0)
+            })
+
+            it("should return rank 1 (Petty Officer) for 10 stars", () => {
+                expect(calculateRank(10, 1999)).toBe(1)
+            })
+
+            it("should return rank 1 (Petty Officer) for 69 stars", () => {
+                expect(calculateRank(69, 1999)).toBe(1)
+            })
+
+            it("should return rank 2 (Master Chief) for 70 stars", () => {
+                expect(calculateRank(70, 1999)).toBe(2)
+            })
+
+            it("should return rank 2 (Master Chief) for 249 stars", () => {
+                expect(calculateRank(249, 1999)).toBe(2)
+            })
+
+            it("should return rank 3 (Warrant) for 250 stars", () => {
+                expect(calculateRank(250, 1999)).toBe(3)
+            })
+
+            it("should return rank 3 (Warrant) for very high stars", () => {
+                expect(calculateRank(50000, 1999)).toBe(3) // max rank is 3 in free version
+            })
+
+            it("should use free thresholds for any version < 2000", () => {
+                expect(calculateRank(1000, 100)).toBe(3)
+                expect(calculateRank(1000, 1000)).toBe(3)
+                expect(calculateRank(1000, 1500)).toBe(3)
+            })
+        })
+
+        describe("version boundary", () => {
+            it("should use free thresholds for version 1999", () => {
+                expect(calculateRank(1000, 1999)).toBe(3) // Warrant (max in free)
+            })
+
+            it("should use paid thresholds for version 2000", () => {
+                expect(calculateRank(1000, 2000)).toBe(6) // Admiral in paid
+            })
+
+            it("should use paid thresholds for version > 2000", () => {
+                expect(calculateRank(1000, 2500)).toBe(6) // Admiral in paid
+            })
+        })
+    })
+
+    describe("RANK_THRESHOLDS", () => {
+        it("should have 9 rank thresholds (paid)", () => {
+            expect(RANK_THRESHOLDS).toHaveLength(9)
+            expect(RANK_THRESHOLDS_PAID).toHaveLength(9)
+        })
+
+        it("should have 4 rank thresholds (free)", () => {
+            expect(RANK_THRESHOLDS_FREE).toHaveLength(4)
+        })
+
+        it("should be sorted by stars descending (paid)", () => {
+            for (let i = 1; i < RANK_THRESHOLDS_PAID.length; i++) {
+                expect(RANK_THRESHOLDS_PAID[i - 1].stars).toBeGreaterThan(
+                    RANK_THRESHOLDS_PAID[i].stars
+                )
+            }
+        })
+
+        it("should be sorted by stars descending (free)", () => {
+            for (let i = 1; i < RANK_THRESHOLDS_FREE.length; i++) {
+                expect(RANK_THRESHOLDS_FREE[i - 1].stars).toBeGreaterThan(
+                    RANK_THRESHOLDS_FREE[i].stars
+                )
+            }
+        })
+
+        it("PAID_VERSION_MIN should be 2000", () => {
+            expect(PAID_VERSION_MIN).toBe(2000)
+        })
     })
 
     describe("validateSession", () => {
@@ -194,9 +513,23 @@ describe("services/navalclash/gameService", () => {
         })
 
         it("should store field and send fldinfo message", async () => {
-            mockConnection.execute
-                .mockResolvedValueOnce([[{ user_one_id: 10, user_two_id: 20 }]])
-                .mockResolvedValueOnce([{ affectedRows: 1 }])
+            // 1. storeFieldData - SELECT game_sessions
+            mockConnection.execute.mockResolvedValueOnce([
+                [{ user_one_id: 10, user_two_id: 20 }],
+            ])
+            // 2. storeFieldData - INSERT gamefields
+            mockConnection.execute.mockResolvedValueOnce([{ affectedRows: 1 }])
+            // 3. getSessionPlayersInfo - SELECT with ranks
+            mockConnection.execute.mockResolvedValueOnce([
+                [
+                    {
+                        user_one_id: 10,
+                        user_two_id: 20,
+                        rank_one: 3,
+                        rank_two: 5,
+                    },
+                ],
+            ])
 
             const req = {
                 requestId: "test",
@@ -205,9 +538,19 @@ describe("services/navalclash/gameService", () => {
 
             await fieldInfo(req, mockRes)
 
-            expect(sendMessage).toHaveBeenCalledWith(1000n, "fldinfo", {
-                json: { ships: [] },
-            })
+            // Now includes bns object
+            expect(sendMessage).toHaveBeenCalledWith(
+                1000n,
+                "fldinfo",
+                expect.objectContaining({
+                    json: { ships: [] },
+                    bns: expect.objectContaining({
+                        type: "bns",
+                        gbc: expect.any(Array),
+                        gbs: expect.any(Array),
+                    }),
+                })
+            )
             expect(mockRes.json).toHaveBeenCalledWith({ type: "ok" })
         })
 
@@ -226,6 +569,70 @@ describe("services/navalclash/gameService", () => {
                 errcode: 5,
                 reason: "Session not found",
             })
+        })
+
+        it("should inject bns object with correct values when forwarding fldinfo", async () => {
+            // 1. storeFieldData - SELECT game_sessions
+            mockConnection.execute.mockResolvedValueOnce([
+                [{ user_one_id: 10, user_two_id: 20 }],
+            ])
+            // 2. storeFieldData - INSERT gamefields
+            mockConnection.execute.mockResolvedValueOnce([{ affectedRows: 1 }])
+            // 3. getSessionPlayersInfo - SELECT with ranks
+            // Player 0 (user 10) has rank 3, Player 1 (user 20) has rank 7
+            mockConnection.execute.mockResolvedValueOnce([
+                [
+                    {
+                        user_one_id: 10,
+                        user_two_id: 20,
+                        rank_one: 3,
+                        rank_two: 7,
+                    },
+                ],
+            ])
+
+            const req = {
+                requestId: "test",
+                body: { sid: "1000", json: { ships: [] } }, // Player 0 sends field
+            }
+
+            await fieldInfo(req, mockRes)
+
+            // Player 0 (rank 3) sends to Player 1 (rank 7)
+            // So opponent (Player 1) has myRank=7, opponentRank=3
+            // WIN bonus for player 1 = 9 + (3 - 7) = 9 + (-4) = 5
+            // All values are encoded with val2mess()
+            expect(sendMessage).toHaveBeenCalledWith(
+                1000n,
+                "fldinfo",
+                expect.objectContaining({
+                    json: { ships: [] },
+                    bns: {
+                        type: "bns",
+                        gbc: [
+                            val2mess(5),
+                            val2mess(-1),
+                            val2mess(2),
+                            val2mess(-2),
+                            val2mess(1),
+                            val2mess(0),
+                            val2mess(0),
+                            val2mess(2),
+                        ],
+                        gbs: [
+                            val2mess(4),
+                            val2mess(0),
+                            val2mess(1),
+                            val2mess(0),
+                            val2mess(1),
+                            val2mess(0),
+                            val2mess(0),
+                            val2mess(0),
+                        ],
+                    },
+                })
+            )
+            expect(mockRes.json).toHaveBeenCalledWith({ type: "ok" })
         })
     })
 
@@ -334,7 +741,9 @@ describe("services/navalclash/gameService", () => {
         })
 
         it("should return error if session not found", async () => {
-            mockConnection.execute.mockResolvedValueOnce([[]])
+            mockConnection.execute
+                .mockResolvedValueOnce([]) // SET TRANSACTION ISOLATION LEVEL
+                .mockResolvedValueOnce([[]]) // SELECT game_sessions FOR UPDATE
 
             const req = {
                 requestId: "test",
@@ -351,19 +760,52 @@ describe("services/navalclash/gameService", () => {
             })
         })
 
-        it("should update stats and finish game", async () => {
+        it("should update stats and finish game with coin calculation", async () => {
             const gameSession = {
                 id: 1000,
-                status: 0,
+                status: 1, // IN_PROGRESS
                 user_one_id: 10,
                 user_two_id: 20,
+                version_one: 2100,
+                version_two: 2100,
+            }
+
+            const mockUser = {
+                id: 10,
+                name: "Winner",
+                uuid: "uuid-10",
+                rank: 3,
+                stars: 100,
+                games: 50,
+                gameswon: 25,
+                coins: 120,
+                games_android: 10,
+                games_bluetooth: 5,
+                games_web: 30,
+                games_passplay: 5,
+                wins_android: 5,
+                wins_bluetooth: 2,
+                wins_web: 15,
+                wins_passplay: 3,
             }
 
             mockConnection.execute
-                .mockResolvedValueOnce([[gameSession]]) // SELECT
+                .mockResolvedValueOnce([]) // SET TRANSACTION ISOLATION LEVEL
+                .mockResolvedValueOnce([[gameSession]]) // SELECT game_sessions FOR UPDATE
                 .mockResolvedValueOnce([{ affectedRows: 1 }]) // UPDATE game_sessions
-                .mockResolvedValueOnce([{ affectedRows: 1 }]) // UPDATE users (winner)
-                .mockResolvedValueOnce([{ affectedRows: 1 }]) // UPDATE users (loser)
+                .mockResolvedValueOnce([{ affectedRows: 1 }]) // UPDATE users (winner stats)
+                .mockResolvedValueOnce([{ affectedRows: 1 }]) // UPDATE users (loser stats)
+                .mockResolvedValueOnce([
+                    [
+                        { id: 10, rank: 3 },
+                        { id: 20, rank: 5 },
+                    ],
+                ]) // SELECT ranks for coin calc
+                .mockResolvedValueOnce([{ affectedRows: 1 }]) // UPDATE coins (winner)
+                .mockResolvedValueOnce([[{ coins: 120 }]]) // SELECT new balance (winner)
+                .mockResolvedValueOnce([{ affectedRows: 1 }]) // UPDATE coins (loser)
+                .mockResolvedValueOnce([[{ coins: 99 }]]) // SELECT new balance (loser)
+                .mockResolvedValueOnce([[mockUser]]) // SELECT user for buildMdfMessage
 
             const req = {
                 requestId: "test",
@@ -382,7 +824,13 @@ describe("services/navalclash/gameService", () => {
                 gsi: undefined,
                 sur: undefined,
             })
-            expect(mockRes.json).toHaveBeenCalledWith({ type: "ok" })
+            // done is returned directly, not { type: "ok" }
+            expect(mockRes.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "done",
+                    cc: 120, // winner's coins (PLAIN)
+                })
+            )
         })
 
         it("should skip stats update if game already finished", async () => {
@@ -391,9 +839,34 @@ describe("services/navalclash/gameService", () => {
                 status: 4, // FINISHED_SURRENDERED - already finished by surrender
                 user_one_id: 10,
                 user_two_id: 20,
+                version_one: 2100,
+                version_two: 2100,
             }
 
-            mockConnection.execute.mockResolvedValueOnce([[gameSession]])
+            const mockUser = {
+                id: 10,
+                name: "Player",
+                uuid: "uuid-10",
+                rank: 3,
+                stars: 100,
+                games: 50,
+                gameswon: 25,
+                coins: 150,
+                games_android: 10,
+                games_bluetooth: 5,
+                games_web: 30,
+                games_passplay: 5,
+                wins_android: 5,
+                wins_bluetooth: 2,
+                wins_web: 15,
+                wins_passplay: 3,
+            }
+
+            mockConnection.execute
+                .mockResolvedValueOnce([]) // SET TRANSACTION ISOLATION LEVEL
+                .mockResolvedValueOnce([[gameSession]]) // SELECT game_sessions FOR UPDATE
+                .mockResolvedValueOnce([[{ coins: 150 }]]) // SELECT coins for this user
+                .mockResolvedValueOnce([[mockUser]]) // SELECT user for buildMdfMessage
 
             const req = {
                 requestId: "test",
@@ -403,8 +876,13 @@ describe("services/navalclash/gameService", () => {
             await finish(req, mockRes)
 
             expect(mockConnection.commit).toHaveBeenCalled()
-            expect(mockConnection.execute).toHaveBeenCalledTimes(1) // Only SELECT
-            expect(mockRes.json).toHaveBeenCalledWith({ type: "ok" })
+            // done is returned directly even for already finished games
+            expect(mockRes.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "done",
+                    cc: 150, // current coins (PLAIN)
+                })
+            )
         })
     })
 

--- a/services/navalclash/gameService.test.js
+++ b/services/navalclash/gameService.test.js
@@ -74,18 +74,21 @@ const {
     shipMove,
     validateSession,
     determineWinnerLoser,
-    BONUS_TYPE,
     calculateWinBonus,
     calculateBonusCoins,
     clamp,
     buildBonusObject,
-    PAID_VERSION_MIN,
-    RANK_THRESHOLDS,
-    RANK_THRESHOLDS_PAID,
-    RANK_THRESHOLDS_FREE,
     calculateRank,
     val2mess,
 } = require("./gameService")
+
+const {
+    BONUS_TYPE,
+    VERSION,
+    RANK_THRESHOLDS,
+    RANK_THRESHOLDS_PAID,
+    RANK_THRESHOLDS_FREE,
+} = require("./constants")
 
 const { sendMessage } = require("./messageService")
 
@@ -372,33 +375,33 @@ describe("services/navalclash/gameService", () => {
     })
 
     describe("RANK_THRESHOLDS", () => {
-        it("should have 9 rank thresholds (paid)", () => {
-            expect(RANK_THRESHOLDS).toHaveLength(9)
-            expect(RANK_THRESHOLDS_PAID).toHaveLength(9)
+        it("should have 11 rank thresholds (paid)", () => {
+            expect(RANK_THRESHOLDS).toHaveLength(11)
+            expect(RANK_THRESHOLDS_PAID).toHaveLength(11)
         })
 
-        it("should have 4 rank thresholds (free)", () => {
-            expect(RANK_THRESHOLDS_FREE).toHaveLength(4)
+        it("should have 11 rank thresholds (free)", () => {
+            expect(RANK_THRESHOLDS_FREE).toHaveLength(11)
         })
 
-        it("should be sorted by stars descending (paid)", () => {
+        it("should be sorted by stars ascending (paid)", () => {
             for (let i = 1; i < RANK_THRESHOLDS_PAID.length; i++) {
-                expect(RANK_THRESHOLDS_PAID[i - 1].stars).toBeGreaterThan(
-                    RANK_THRESHOLDS_PAID[i].stars
+                expect(RANK_THRESHOLDS_PAID[i]).toBeGreaterThanOrEqual(
+                    RANK_THRESHOLDS_PAID[i - 1]
                 )
             }
         })
 
-        it("should be sorted by stars descending (free)", () => {
+        it("should be sorted by stars ascending (free)", () => {
             for (let i = 1; i < RANK_THRESHOLDS_FREE.length; i++) {
-                expect(RANK_THRESHOLDS_FREE[i - 1].stars).toBeGreaterThan(
-                    RANK_THRESHOLDS_FREE[i].stars
+                expect(RANK_THRESHOLDS_FREE[i]).toBeGreaterThanOrEqual(
+                    RANK_THRESHOLDS_FREE[i - 1]
                 )
             }
         })
 
-        it("PAID_VERSION_MIN should be 2000", () => {
-            expect(PAID_VERSION_MIN).toBe(2000)
+        it("VERSION.PAID_MIN should be 2000", () => {
+            expect(VERSION.PAID_MIN).toBe(2000)
         })
     })
 

--- a/services/navalclash/gameService.test.js
+++ b/services/navalclash/gameService.test.js
@@ -36,7 +36,9 @@ jest.mock("../../db/navalclash", () => ({
 }))
 
 jest.mock("./weaponService", () => ({
-    validateWeaponPlacement: jest.fn().mockResolvedValue({ valid: true, counts: {} }),
+    validateWeaponPlacement: jest
+        .fn()
+        .mockResolvedValue({ valid: true, counts: {} }),
     trackWeaponPlacement: jest.fn().mockResolvedValue(true),
     trackRadarUsage: jest.fn().mockResolvedValue(true),
     trackShuffleUsage: jest.fn().mockResolvedValue(true),
@@ -179,18 +181,26 @@ describe("services/navalclash/gameService", () => {
 
         it("should return half of win bonus for SURRENDER_WIN_BONUS", () => {
             // Win bonus would be 13, half is 6
-            expect(calculateBonusCoins(BONUS_TYPE.SURRENDER_WIN_BONUS, 2, 6)).toBe(6)
+            expect(
+                calculateBonusCoins(BONUS_TYPE.SURRENDER_WIN_BONUS, 2, 6)
+            ).toBe(6)
         })
 
         it("should return at least 1 for SURRENDER_WIN_BONUS", () => {
             // Win bonus would be 4, half is 2, so return 2
-            expect(calculateBonusCoins(BONUS_TYPE.SURRENDER_WIN_BONUS, 10, 1)).toBe(2)
+            expect(
+                calculateBonusCoins(BONUS_TYPE.SURRENDER_WIN_BONUS, 10, 1)
+            ).toBe(2)
             // Even with very low bonus, minimum is 1
-            expect(calculateBonusCoins(BONUS_TYPE.SURRENDER_WIN_BONUS, 5, 5)).toBe(4) // 9/2 = 4
+            expect(
+                calculateBonusCoins(BONUS_TYPE.SURRENDER_WIN_BONUS, 5, 5)
+            ).toBe(4) // 9/2 = 4
         })
 
         it("should return -2 for SURRENDER_LOST_BONUS", () => {
-            expect(calculateBonusCoins(BONUS_TYPE.SURRENDER_LOST_BONUS)).toBe(-2)
+            expect(calculateBonusCoins(BONUS_TYPE.SURRENDER_LOST_BONUS)).toBe(
+                -2
+            )
         })
 
         it("should return 1 for INTERRUPT_WIN_BONUS", () => {
@@ -202,7 +212,9 @@ describe("services/navalclash/gameService", () => {
         })
 
         it("should return +2 for LOST_BONUS_WITH_WEAPONS", () => {
-            expect(calculateBonusCoins(BONUS_TYPE.LOST_BONUS_WITH_WEAPONS)).toBe(2)
+            expect(
+                calculateBonusCoins(BONUS_TYPE.LOST_BONUS_WITH_WEAPONS)
+            ).toBe(2)
         })
 
         it("should return 0 for unknown bonus type", () => {
@@ -492,11 +504,11 @@ describe("services/navalclash/gameService", () => {
         it("should send greeting message to opponent", async () => {
             await greeting(mockReq, mockRes)
 
-            expect(sendMessage).toHaveBeenCalledWith(
-                1000n,
-                "greeting",
-                { u: { name: "Player1" }, v: 1, ni: "info" }
-            )
+            expect(sendMessage).toHaveBeenCalledWith(1000n, "greeting", {
+                u: { name: "Player1" },
+                v: 1,
+                ni: "info",
+            })
             expect(mockRes.json).toHaveBeenCalledWith({ type: "ok" })
         })
     })

--- a/services/navalclash/handshakeService.js
+++ b/services/navalclash/handshakeService.js
@@ -1,0 +1,115 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ */
+
+const {
+    parseHandshakeRequest,
+    rsaDecrypt,
+    aesGcmEncrypt,
+    generateDeviceToken,
+    tokenToBase64,
+} = require("../../utils/encryption")
+const { dbStoreDeviceKey } = require("../../db/navalclash/keys")
+const { logger } = require("../../utils/logger")
+
+// Generic error response - never leak details to client
+const PROTOCOL_ERROR = { error: "PROTOCOL_ERROR" }
+
+// Token TTL: 4 hours
+const TOKEN_TTL_SECONDS = 4 * 60 * 60
+
+/**
+ * POST /handshake - Establish encryption key.
+ * Binary format: [sig 2][ver 1][keyIdx 1][len 2][RSA-encrypted JSON]
+ * Response: AES-encrypted JSON with device token.
+ *
+ * @param {Object} req - Express request with raw binary body
+ * @param {Object} res - Express response
+ */
+async function handshake(req, res) {
+    // Parse binary handshake request
+    let keyIndex, encrypted
+    try {
+        ;({ keyIndex, encrypted } = parseHandshakeRequest(req.body))
+    } catch (error) {
+        logger.error({}, "Handshake: parse error:", error.message)
+        return res.status(400).json(PROTOCOL_ERROR)
+    }
+
+    // Decrypt with appropriate RSA private key
+    let payload
+    try {
+        const decrypted = rsaDecrypt(encrypted, keyIndex)
+        payload = JSON.parse(decrypted.toString("utf8"))
+    } catch (error) {
+        logger.error(
+            {},
+            "Handshake: decrypt error (ki=" + keyIndex + "):",
+            error.message
+        )
+        return res.status(400).json(PROTOCOL_ERROR)
+    }
+
+    // Extract and validate fields
+    const { key: keyBase64, uuid, uuuid, v, p } = payload
+
+    if (!keyBase64 || !uuid) {
+        logger.error(
+            {},
+            "Handshake: missing fields, uuid:",
+            uuid ? "present" : "missing",
+            "key:",
+            keyBase64 ? "present" : "missing"
+        )
+        return res.status(400).json(PROTOCOL_ERROR)
+    }
+
+    // Decode AES key
+    const deviceKey = Buffer.from(keyBase64, "base64")
+    if (deviceKey.length !== 32) {
+        logger.error({}, "Handshake: invalid key length:", deviceKey.length)
+        return res.status(400).json(PROTOCOL_ERROR)
+    }
+
+    // Generate device token
+    const tokenBinary = generateDeviceToken(TOKEN_TTL_SECONDS)
+    const tokenBase64 = tokenToBase64(tokenBinary)
+
+    // Store token -> key mapping
+    const stored = await dbStoreDeviceKey(
+        tokenBase64,
+        deviceKey,
+        uuid,
+        TOKEN_TTL_SECONDS
+    )
+    if (!stored) {
+        logger.error({ did: uuid }, "Handshake: failed to store device key")
+        return res.status(500).json(PROTOCOL_ERROR)
+    }
+
+    logger.info(
+        { did: uuid },
+        "Handshake: success, ki=" + keyIndex,
+        "v=" + v,
+        "p=" + p
+    )
+
+    // Build and encrypt response
+    const responseJson = JSON.stringify({
+        type: "ok",
+        dt: tokenBase64,
+    })
+
+    const { iv, ciphertext } = aesGcmEncrypt(
+        deviceKey,
+        Buffer.from(responseJson, "utf8")
+    )
+
+    // Return binary: [12 byte IV][ciphertext + tag]
+    res.set("Content-Type", "application/octet-stream")
+    res.send(Buffer.concat([iv, ciphertext]))
+}
+
+module.exports = { handshake }

--- a/services/navalclash/handshakeService.test.js
+++ b/services/navalclash/handshakeService.test.js
@@ -1,0 +1,223 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ */
+
+const crypto = require("crypto")
+
+// Mock encryption module
+const mockParseHandshakeRequest = jest.fn()
+const mockRsaDecrypt = jest.fn()
+const mockAesGcmEncrypt = jest.fn()
+const mockGenerateDeviceToken = jest.fn()
+const mockTokenToBase64 = jest.fn()
+
+jest.mock("../../utils/encryption", () => ({
+    parseHandshakeRequest: mockParseHandshakeRequest,
+    rsaDecrypt: mockRsaDecrypt,
+    aesGcmEncrypt: mockAesGcmEncrypt,
+    generateDeviceToken: mockGenerateDeviceToken,
+    tokenToBase64: mockTokenToBase64,
+}))
+
+// Mock DB
+const mockDbStoreDeviceKey = jest.fn()
+jest.mock("../../db/navalclash/keys", () => ({
+    dbStoreDeviceKey: mockDbStoreDeviceKey,
+}))
+
+// Mock logger
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}))
+
+const { handshake } = require("./handshakeService")
+
+describe("handshakeService", () => {
+    let req, res
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+
+        req = {
+            body: Buffer.alloc(262), // big enough binary body
+        }
+        res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn().mockReturnThis(),
+            send: jest.fn().mockReturnThis(),
+            set: jest.fn().mockReturnThis(),
+        }
+    })
+
+    it("should return 400 when parse fails", async () => {
+        mockParseHandshakeRequest.mockImplementation(() => {
+            throw new Error("Handshake too short")
+        })
+
+        await handshake(req, res)
+
+        expect(res.status).toHaveBeenCalledWith(400)
+        expect(res.json).toHaveBeenCalledWith({ error: "PROTOCOL_ERROR" })
+    })
+
+    it("should return 400 when RSA decrypt fails", async () => {
+        mockParseHandshakeRequest.mockReturnValue({
+            keyIndex: 0,
+            encrypted: Buffer.alloc(256),
+        })
+        mockRsaDecrypt.mockImplementation(() => {
+            throw new Error("Decryption failed")
+        })
+
+        await handshake(req, res)
+
+        expect(res.status).toHaveBeenCalledWith(400)
+        expect(res.json).toHaveBeenCalledWith({ error: "PROTOCOL_ERROR" })
+    })
+
+    it("should return 400 when uuid is missing", async () => {
+        const payload = JSON.stringify({
+            key: crypto.randomBytes(32).toString("base64"),
+            // uuid missing
+        })
+
+        mockParseHandshakeRequest.mockReturnValue({
+            keyIndex: 0,
+            encrypted: Buffer.alloc(256),
+        })
+        mockRsaDecrypt.mockReturnValue(Buffer.from(payload))
+
+        await handshake(req, res)
+
+        expect(res.status).toHaveBeenCalledWith(400)
+        expect(res.json).toHaveBeenCalledWith({ error: "PROTOCOL_ERROR" })
+    })
+
+    it("should return 400 when key is missing", async () => {
+        const payload = JSON.stringify({
+            uuid: "test-uuid",
+            // key missing
+        })
+
+        mockParseHandshakeRequest.mockReturnValue({
+            keyIndex: 0,
+            encrypted: Buffer.alloc(256),
+        })
+        mockRsaDecrypt.mockReturnValue(Buffer.from(payload))
+
+        await handshake(req, res)
+
+        expect(res.status).toHaveBeenCalledWith(400)
+        expect(res.json).toHaveBeenCalledWith({ error: "PROTOCOL_ERROR" })
+    })
+
+    it("should return 400 when key is wrong length", async () => {
+        const payload = JSON.stringify({
+            key: Buffer.from("short").toString("base64"),
+            uuid: "test-uuid",
+        })
+
+        mockParseHandshakeRequest.mockReturnValue({
+            keyIndex: 0,
+            encrypted: Buffer.alloc(256),
+        })
+        mockRsaDecrypt.mockReturnValue(Buffer.from(payload))
+
+        await handshake(req, res)
+
+        expect(res.status).toHaveBeenCalledWith(400)
+        expect(res.json).toHaveBeenCalledWith({ error: "PROTOCOL_ERROR" })
+    })
+
+    it("should return 500 when DB store fails", async () => {
+        const aesKey = crypto.randomBytes(32)
+        const payload = JSON.stringify({
+            key: aesKey.toString("base64"),
+            uuid: "test-uuid",
+            uuuid: "user-uuid",
+            v: 26,
+            p: "android",
+        })
+        const token = crypto.randomBytes(32)
+
+        mockParseHandshakeRequest.mockReturnValue({
+            keyIndex: 0,
+            encrypted: Buffer.alloc(256),
+        })
+        mockRsaDecrypt.mockReturnValue(Buffer.from(payload))
+        mockGenerateDeviceToken.mockReturnValue(token)
+        mockTokenToBase64.mockReturnValue("dG9rZW4tYmFzZTY0")
+        mockDbStoreDeviceKey.mockResolvedValue(false)
+
+        await handshake(req, res)
+
+        expect(res.status).toHaveBeenCalledWith(500)
+        expect(res.json).toHaveBeenCalledWith({ error: "PROTOCOL_ERROR" })
+    })
+
+    it("should succeed with valid handshake", async () => {
+        const aesKey = crypto.randomBytes(32)
+        const payload = JSON.stringify({
+            key: aesKey.toString("base64"),
+            uuid: "test-device-uuid",
+            uuuid: "test-user-uuid",
+            v: 26,
+            p: "android",
+        })
+        const token = crypto.randomBytes(32)
+        const tokenB64 = "dG9rZW4tYmFzZTY0AAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        const respIv = crypto.randomBytes(12)
+        const respCiphertext = Buffer.from("encrypted-response")
+
+        mockParseHandshakeRequest.mockReturnValue({
+            keyIndex: 2,
+            encrypted: Buffer.alloc(256),
+        })
+        mockRsaDecrypt.mockReturnValue(Buffer.from(payload))
+        mockGenerateDeviceToken.mockReturnValue(token)
+        mockTokenToBase64.mockReturnValue(tokenB64)
+        mockDbStoreDeviceKey.mockResolvedValue(true)
+        mockAesGcmEncrypt.mockReturnValue({
+            iv: respIv,
+            ciphertext: respCiphertext,
+        })
+
+        await handshake(req, res)
+
+        // Verify DB store was called correctly
+        expect(mockDbStoreDeviceKey).toHaveBeenCalledWith(
+            tokenB64,
+            aesKey,
+            "test-device-uuid",
+            4 * 60 * 60
+        )
+
+        // Verify AES encrypt was called with correct response
+        expect(mockAesGcmEncrypt).toHaveBeenCalledWith(
+            aesKey,
+            expect.any(Buffer)
+        )
+
+        // Verify the plaintext passed to encrypt contains the token
+        const encryptCall = mockAesGcmEncrypt.mock.calls[0]
+        const responsePlaintext = JSON.parse(encryptCall[1].toString("utf8"))
+        expect(responsePlaintext.type).toBe("ok")
+        expect(responsePlaintext.dt).toBe(tokenB64)
+
+        // Verify binary response
+        expect(res.set).toHaveBeenCalledWith(
+            "Content-Type",
+            "application/octet-stream"
+        )
+        expect(res.send).toHaveBeenCalledWith(
+            Buffer.concat([respIv, respCiphertext])
+        )
+    })
+})

--- a/services/navalclash/leaderboardService.js
+++ b/services/navalclash/leaderboardService.js
@@ -4,61 +4,359 @@
  * All rights reserved.
  */
 
-const { pool } = require("../../db/navalclash")
+const {
+    dbGetTopScores,
+    dbGetTopScoresByType,
+    dbSubmitScore,
+    dbGetUserLeaderboardRank,
+    dbGetTopStars,
+    dbFindUserByUuid,
+    dbFindUserByUuidAndName,
+    dbCreateUser,
+    TOPSCORE_THRESHOLD,
+    MIN_GAME_TIME_MS,
+} = require("../../db/navalclash")
 const { logger } = require("../../utils/logger")
 
 /**
  * Serializes a score entry for API response.
+ * Matches the client's Score object format with PlayerInfo for user and opponent.
  *
- * @param {Object} row - Database row
- * @param {number} position - Position in leaderboard
- * @returns {Object} Serialized score
+ * @param {Object} row - Database row with user/opponent info
+ * @returns {Object} Serialized score matching client format
  */
-function serializeScore(row, position) {
-    return {
-        pos: position,
-        id: row.user_id,
-        n: row.name,
-        f: row.face,
-        uuid: row.uuid,
-        sc: row.score,
-        tm: row.time_spent_ms,
-        d: row.created_at,
+function serializeScore(row) {
+    const result = {
+        type: "Score",
+        score: row.score,
+        time: row.time_spent_ms || 30001, // Fallback to minimum valid time if missing
+        gtype: dbGtypeToClient(row.game_type), // Convert DB (1-4) to client (0-3)
+        ct: row.created_at ? new Date(row.created_at).getTime() : Date.now(),
+        // Winner player info
+        u: {
+            nam: row.name,
+            i: row.user_id,
+            rk: row.user_rank || 0,
+            fc: row.face || 0,
+            id: row.uuid || "",
+        },
     }
+
+    // Only include opponent if available (client checks has("o") before getJSONObject)
+    if (row.opponent_id) {
+        result.o = {
+            nam: row.opponent_name || "",
+            i: row.opponent_id,
+            rk: row.opponent_rank || 0,
+            fc: row.opponent_face || 0,
+        }
+    }
+
+    return result
+}
+
+/**
+ * Serializes a topstars entry for API response.
+ * TopStars ranks players by accumulated stars, not individual game scores.
+ * Note: Does not include 'o' field - client checks has("o") before getJSONObject.
+ *
+ * @param {Object} row - User row from database
+ * @returns {Object} Serialized star ranking entry
+ */
+function serializeStarEntry(row) {
+    return {
+        type: "Score",
+        score: row.stars || 0,
+        time: 30001, // Minimum valid time (client requires >= 30000ms)
+        gtype: 3, // Default to web
+        ct: Date.now(),
+        u: {
+            nam: row.name,
+            i: row.id,
+            rk: row.rank || 0,
+            fc: row.face || 0,
+            id: row.uuid || "",
+            st: row.stars || 0,
+            pld: row.games || 0,
+            won: row.gameswon || 0,
+            ga: [
+                row.games_android || 0,
+                row.games_bluetooth || 0,
+                row.games_web || 0,
+                row.games_passplay || 0,
+            ],
+            wa: [
+                row.wins_android || 0,
+                row.wins_bluetooth || 0,
+                row.wins_web || 0,
+                row.wins_passplay || 0,
+            ],
+        },
+        // No 'o' field - topstars entries don't have opponents
+    }
+}
+
+// Minimum client version to include topstars in response
+const TOPSTARS_MIN_VERSION = 30
+
+// Map client game type to database game type
+// Client: 0=Android, 1=Bluetooth, 2=Web, 3=PassPlay
+// Database: 1=android, 2=bt, 3=web, 4=passplay
+// Conversion: DB = client + 1
+function clientGtypeToDb(clientGtype) {
+    // Client uses 0-3, DB uses 1-4
+    const dbType = (clientGtype || 0) + 1
+    // Clamp to valid range 1-4
+    return Math.max(1, Math.min(4, dbType))
+}
+
+// Map database game type back to client game type
+// Database: 1=android, 2=bt, 3=web, 4=passplay
+// Client: 0=Android, 1=Bluetooth, 2=Web, 3=PassPlay
+// Conversion: client = DB - 1
+function dbGtypeToClient(dbGameType) {
+    return (dbGameType || 1) - 1
+}
+
+/**
+ * Checks if a UUID is valid for user lookup/creation.
+ * Invalid UUIDs include placeholder values like "android" or "null".
+ *
+ * @param {string} uuid - UUID to validate
+ * @returns {boolean} True if valid
+ */
+function isValidUuid(uuid) {
+    return uuid && uuid !== "android" && uuid !== "null" && uuid.length >= 10
+}
+
+/**
+ * Gets or creates a user by UUID and name.
+ * Mimics the old Java server behavior: if user not found, create them.
+ *
+ * @param {string} uuid - User UUID
+ * @param {string} name - User name
+ * @param {number} gameVariant - Game variant for new users
+ * @param {Object} ctx - Logging context
+ * @returns {Promise<Object|null>} User object or null if invalid UUID
+ */
+async function getOrCreateUser(uuid, name, gameVariant, ctx) {
+    if (!isValidUuid(uuid)) {
+        return null
+    }
+
+    // First try to find by UUID and name (exact match)
+    let user = await dbFindUserByUuidAndName(uuid, name)
+    if (user) {
+        return user
+    }
+
+    // Try to find by UUID only (name might have changed)
+    user = await dbFindUserByUuid(uuid)
+    if (user) {
+        return user
+    }
+
+    // User not found - create new user (like old Java server)
+    logger.info(
+        { ...ctx, uuid, name },
+        "Creating new user from client score"
+    )
+    const newUserId = await dbCreateUser({
+        name: name || "Player",
+        uuid,
+        gameVariant,
+    })
+
+    if (newUserId) {
+        // Return a minimal user object with the new ID
+        return { id: newUserId, name: name || "Player", uuid }
+    }
+
+    logger.error({ ...ctx, uuid, name }, "Failed to create user")
+    return null
+}
+
+/**
+ * Processes client scores and inserts valid ones into the database.
+ * Creates users if they don't exist (like old Java server).
+ *
+ * @param {Array} clientScores - Array of score objects from client
+ * @param {number} gameVariant - Game variant
+ * @param {Object} ctx - Logging context
+ * @returns {Promise<number>} Number of scores inserted
+ */
+async function processClientScores(clientScores, gameVariant, ctx) {
+    if (!clientScores || clientScores.length === 0) {
+        return 0
+    }
+
+    let inserted = 0
+
+    for (const score of clientScores) {
+        try {
+            // Validate score structure
+            if (!score.u || !score.u.id || !score.score || !score.time) {
+                logger.debug(
+                    { ...ctx, score: score.score },
+                    "Skipping score: missing required fields"
+                )
+                continue
+            }
+
+            // Skip scores with invalid UUIDs (like "android")
+            if (!isValidUuid(score.u.id)) {
+                logger.debug(
+                    { ...ctx, uuid: score.u.id },
+                    "Skipping score: invalid user UUID"
+                )
+                continue
+            }
+
+            // Get or create user (like old Java server behavior)
+            const user = await getOrCreateUser(
+                score.u.id,
+                score.u.nam,
+                gameVariant,
+                ctx
+            )
+            if (!user) {
+                logger.debug(
+                    { ...ctx, uuid: score.u.id },
+                    "Skipping score: failed to get/create user"
+                )
+                continue
+            }
+
+            // Get or create opponent if available
+            let opponentId = null
+            let opponentRank = 0
+            if (score.o && isValidUuid(score.o.id)) {
+                const opponent = await getOrCreateUser(
+                    score.o.id,
+                    score.o.nam,
+                    gameVariant,
+                    ctx
+                )
+                if (opponent) {
+                    opponentId = opponent.id
+                    opponentRank = score.o.rk || 0
+                }
+            }
+
+            // Map game type from client format (0-3) to DB format (1-4)
+            const dbGameType = clientGtypeToDb(score.gtype)
+
+            // Submit score (validation happens in dbSubmitScore)
+            const result = await dbSubmitScore({
+                userId: user.id,
+                opponentId,
+                score: score.score,
+                timeMs: score.time,
+                gameType: dbGameType,
+                gameVariant,
+                userRank: score.u.rk || 0,
+                opponentRank,
+            })
+
+            if (result.success) {
+                inserted++
+                logger.info(
+                    { ...ctx, userId: user.id, score: score.score, scoreId: result.scoreId },
+                    "Inserted client score"
+                )
+            }
+        } catch (error) {
+            logger.error(
+                { ...ctx, score: score.score },
+                "Error processing client score:",
+                error.message
+            )
+        }
+    }
+
+    return inserted
 }
 
 /**
  * Get top scores endpoint - returns leaderboard data.
+ * Client sends: { type: "topTen", scores: [...], var, v }
+ * Server responds: { type: "topTen", scores: [...], var, topstars?: {...} }
+ *
+ * For clients with version > 30, also includes topstars (ranking by stars).
  *
  * @param {Object} req - Express request
  * @param {Object} res - Express response
  * @returns {Promise<Object>} JSON response
  */
 async function getTopScores(req, res) {
-    const { uid, limit } = req.body
     const gameVariant = req.body.var || 1
-    const gameType = req.body.tp || 3 // Default to web
-    const ctx = { reqId: req.requestId, uid, gameVariant, gameType }
+    const gameType = req.body.tp // Optional game type filter
+    const clientVersion = req.body.v || 0
+    const clientScores = req.body.scores || []
+    const ctx = { reqId: req.requestId, gameVariant, gameType, v: clientVersion }
 
-    logger.debug(ctx, "Get top scores request")
+    logger.info(
+        { ...ctx, clientScoreCount: clientScores.length },
+        "TopScores request received"
+    )
+    logger.info(ctx, "TopScores request body:", JSON.stringify(req.body))
 
-    const maxResults = Math.min(limit || 10, 50)
+    const maxResults = 50
 
     try {
-        const [rows] = await pool.execute(
-            `SELECT ts.*, u.name, u.face, u.uuid
-             FROM topscores ts
-             JOIN users u ON u.id = ts.user_id
-             WHERE ts.game_variant = ? AND ts.game_type = ?
-             ORDER BY ts.score DESC
-             LIMIT ?`,
-            [gameVariant, gameType, maxResults]
-        )
+        // Process and insert valid client scores before fetching results
+        if (clientScores.length > 0) {
+            const insertedCount = await processClientScores(
+                clientScores,
+                gameVariant,
+                ctx
+            )
+            logger.info(
+                { ...ctx, insertedCount, totalClientScores: clientScores.length },
+                "Processed client scores"
+            )
+        }
 
-        const scores = rows.map((row, index) => serializeScore(row, index + 1))
+        // Fetch scores - with or without game type filter
+        let rows
+        if (gameType) {
+            rows = await dbGetTopScoresByType(gameVariant, gameType, maxResults)
+        } else {
+            rows = await dbGetTopScores(gameVariant, maxResults)
+        }
 
-        logger.debug({ ...ctx, count: scores.length }, "Returning top scores")
-        return res.json({ type: "top", list: scores })
+        // Serialize scores to client format
+        const scores = rows.map((row) => serializeScore(row))
+
+        // Build response
+        const response = {
+            type: "topTen",
+            scores,
+            var: gameVariant,
+        }
+
+        // Include topstars for clients with version > 30
+        if (clientVersion > TOPSTARS_MIN_VERSION) {
+            const starRows = await dbGetTopStars(gameVariant, maxResults)
+            const starScores = starRows.map((row) => serializeStarEntry(row))
+
+            response.topstars = {
+                type: "topTen",
+                scores: starScores,
+                var: gameVariant,
+            }
+
+            logger.info(
+                { ...ctx, scoreCount: scores.length, starCount: starScores.length },
+                "Returning top scores with topstars"
+            )
+        } else {
+            logger.info({ ...ctx, count: scores.length }, "Returning top scores")
+        }
+
+        logger.info(ctx, "TopScores response:", JSON.stringify(response))
+
+        return res.json(response)
     } catch (error) {
         logger.error(ctx, "getTopScores error:", error.message)
         return res.json({ type: "error", reason: "Database error" })
@@ -66,18 +364,19 @@ async function getTopScores(req, res) {
 }
 
 /**
- * Submits a score to the leaderboard.
+ * Submits a score to the leaderboard with validation.
+ * Checks threshold, game duration, and duplicates.
  *
  * @param {number} userId - User ID
  * @param {number} opponentId - Opponent user ID
  * @param {number} score - Score value
  * @param {number} timeMs - Time spent in ms
- * @param {number} gameType - Game type
+ * @param {number} gameType - Game type (1=android, 2=bt, 3=web, 4=passplay)
  * @param {number} gameVariant - Game variant
  * @param {number} userRank - User's rank
  * @param {number} opponentRank - Opponent's rank
  * @param {Object} ctx - Logging context
- * @returns {Promise<number|null>} New score ID or null on error
+ * @returns {Promise<Object>} Result { success, reason, scoreId }
  */
 async function submitScore(
     userId,
@@ -90,36 +389,52 @@ async function submitScore(
     opponentRank,
     ctx
 ) {
-    try {
-        const [result] = await pool.execute(
-            `INSERT INTO topscores
-                (user_id, opponent_id, score, time_spent_ms, game_type, game_variant, user_rank, opponent_rank)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-            [
-                userId,
-                opponentId,
-                score,
-                timeMs,
-                gameType,
-                gameVariant,
-                userRank,
-                opponentRank,
-            ]
-        )
+    const result = await dbSubmitScore({
+        userId,
+        opponentId,
+        score,
+        timeMs,
+        gameType,
+        gameVariant,
+        userRank,
+        opponentRank,
+    })
+
+    if (result.success) {
         logger.info(
-            { ...ctx, userId, score, scoreId: result.insertId },
+            { ...ctx, userId, score, scoreId: result.scoreId },
             "Score submitted to leaderboard"
         )
-        return result.insertId
-    } catch (error) {
-        logger.error(ctx, "submitScore error:", error.message)
-        return null
+    } else {
+        logger.debug(
+            { ...ctx, userId, score, reason: result.reason },
+            "Score not submitted"
+        )
     }
+
+    return result
+}
+
+/**
+ * Gets a user's leaderboard position.
+ *
+ * @param {number} userId - User ID
+ * @param {number} gameVariant - Game variant
+ * @returns {Promise<number|null>} Rank (1-based) or null if not ranked
+ */
+async function getUserLeaderboardRank(userId, gameVariant) {
+    return dbGetUserLeaderboardRank(userId, gameVariant)
 }
 
 module.exports = {
     getTopScores,
     submitScore,
+    getUserLeaderboardRank,
     // Exported for testing
     serializeScore,
+    serializeStarEntry,
+    // Re-export constants
+    TOPSCORE_THRESHOLD,
+    MIN_GAME_TIME_MS,
+    TOPSTARS_MIN_VERSION,
 }

--- a/services/navalclash/leaderboardService.js
+++ b/services/navalclash/leaderboardService.js
@@ -17,6 +17,7 @@ const {
     MIN_GAME_TIME_MS,
 } = require("../../db/navalclash")
 const { logger } = require("../../utils/logger")
+const { VERSION } = require("./constants")
 
 /**
  * Serializes a score entry for API response.
@@ -95,9 +96,6 @@ function serializeStarEntry(row) {
         // No 'o' field - topstars entries don't have opponents
     }
 }
-
-// Minimum client version to include topstars in response
-const TOPSTARS_MIN_VERSION = 30
 
 // Map client game type to database game type
 // Client: 0=Android, 1=Bluetooth, 2=Web, 3=PassPlay
@@ -336,7 +334,7 @@ async function getTopScores(req, res) {
         }
 
         // Include topstars for clients with version > 30
-        if (clientVersion > TOPSTARS_MIN_VERSION) {
+        if (clientVersion > VERSION.TOPSTARS_MIN) {
             const starRows = await dbGetTopStars(gameVariant, maxResults)
             const starScores = starRows.map((row) => serializeStarEntry(row))
 
@@ -433,8 +431,7 @@ module.exports = {
     // Exported for testing
     serializeScore,
     serializeStarEntry,
-    // Re-export constants
+    // Re-export constants from db layer
     TOPSCORE_THRESHOLD,
     MIN_GAME_TIME_MS,
-    TOPSTARS_MIN_VERSION,
 }

--- a/services/navalclash/leaderboardService.js
+++ b/services/navalclash/leaderboardService.js
@@ -155,10 +155,7 @@ async function getOrCreateUser(uuid, name, gameVariant, ctx) {
     }
 
     // User not found - create new user (like old Java server)
-    logger.info(
-        { ...ctx, uuid, name },
-        "Creating new user from client score"
-    )
+    logger.info({ ...ctx, uuid, name }, "Creating new user from client score")
     const newUserId = await dbCreateUser({
         name: name || "Player",
         uuid,
@@ -259,7 +256,12 @@ async function processClientScores(clientScores, gameVariant, ctx) {
             if (result.success) {
                 inserted++
                 logger.info(
-                    { ...ctx, userId: user.id, score: score.score, scoreId: result.scoreId },
+                    {
+                        ...ctx,
+                        userId: user.id,
+                        score: score.score,
+                        scoreId: result.scoreId,
+                    },
                     "Inserted client score"
                 )
             }
@@ -291,7 +293,12 @@ async function getTopScores(req, res) {
     const gameType = req.body.tp // Optional game type filter
     const clientVersion = req.body.v || 0
     const clientScores = req.body.scores || []
-    const ctx = { reqId: req.requestId, gameVariant, gameType, v: clientVersion }
+    const ctx = {
+        reqId: req.requestId,
+        gameVariant,
+        gameType,
+        v: clientVersion,
+    }
 
     logger.info(
         { ...ctx, clientScoreCount: clientScores.length },
@@ -310,7 +317,11 @@ async function getTopScores(req, res) {
                 ctx
             )
             logger.info(
-                { ...ctx, insertedCount, totalClientScores: clientScores.length },
+                {
+                    ...ctx,
+                    insertedCount,
+                    totalClientScores: clientScores.length,
+                },
                 "Processed client scores"
             )
         }
@@ -345,11 +356,18 @@ async function getTopScores(req, res) {
             }
 
             logger.info(
-                { ...ctx, scoreCount: scores.length, starCount: starScores.length },
+                {
+                    ...ctx,
+                    scoreCount: scores.length,
+                    starCount: starScores.length,
+                },
                 "Returning top scores with topstars"
             )
         } else {
-            logger.info({ ...ctx, count: scores.length }, "Returning top scores")
+            logger.info(
+                { ...ctx, count: scores.length },
+                "Returning top scores"
+            )
         }
 
         logger.info(ctx, "TopScores response:", JSON.stringify(response))

--- a/services/navalclash/leaderboardService.test.js
+++ b/services/navalclash/leaderboardService.test.js
@@ -4,18 +4,48 @@
  * All rights reserved.
  */
 
-const mockExecute = jest.fn()
-
 jest.mock("../../db/navalclash", () => ({
-    pool: {
-        execute: mockExecute,
+    dbGetTopScores: jest.fn(),
+    dbGetTopScoresByType: jest.fn(),
+    dbSubmitScore: jest.fn(),
+    dbGetUserLeaderboardRank: jest.fn(),
+    dbGetTopStars: jest.fn(),
+    dbFindUserByUuid: jest.fn(),
+    dbFindUserByUuidAndName: jest.fn(),
+    dbCreateUser: jest.fn(),
+    TOPSCORE_THRESHOLD: 3000,
+    MIN_GAME_TIME_MS: 30000,
+}))
+
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
     },
 }))
 
 const {
+    dbGetTopScores,
+    dbGetTopScoresByType,
+    dbSubmitScore,
+    dbGetUserLeaderboardRank,
+    dbGetTopStars,
+    dbFindUserByUuid,
+    dbFindUserByUuidAndName,
+    dbCreateUser,
+} = require("../../db/navalclash")
+
+const {
     getTopScores,
     submitScore,
+    getUserLeaderboardRank,
     serializeScore,
+    serializeStarEntry,
+    TOPSCORE_THRESHOLD,
+    MIN_GAME_TIME_MS,
+    TOPSTARS_MIN_VERSION,
 } = require("./leaderboardService")
 
 describe("services/navalclash/leaderboardService", () => {
@@ -24,35 +54,127 @@ describe("services/navalclash/leaderboardService", () => {
     })
 
     describe("serializeScore", () => {
-        it("should serialize score data correctly", () => {
+        it("should serialize score with user and opponent info", () => {
             const row = {
                 user_id: 123,
-                name: "Player1",
+                name: "Winner",
                 face: 5,
-                uuid: "test-uuid",
-                score: 1500,
+                uuid: "winner-uuid",
+                score: 5500,
                 time_spent_ms: 60000,
-                created_at: new Date("2026-01-01"),
+                user_rank: 5,
+                game_type: 3,
+                created_at: new Date("2026-01-15T10:30:00Z"),
+                opponent_id: 456,
+                opponent_name: "Loser",
+                opponent_face: 3,
+                opponent_rank: 4,
             }
 
-            const result = serializeScore(row, 1)
+            const result = serializeScore(row)
 
             expect(result).toEqual({
-                pos: 1,
-                id: 123,
-                n: "Player1",
-                f: 5,
-                uuid: "test-uuid",
-                sc: 1500,
-                tm: 60000,
-                d: row.created_at,
+                type: "Score",
+                score: 5500,
+                time: 60000,
+                gtype: 2, // DB game_type 3 (web) -> client gtype 2 (web)
+                ct: new Date("2026-01-15T10:30:00Z").getTime(),
+                u: {
+                    nam: "Winner",
+                    i: 123,
+                    rk: 5,
+                    fc: 5,
+                    id: "winner-uuid",
+                },
+                o: {
+                    nam: "Loser",
+                    i: 456,
+                    rk: 4,
+                    fc: 3,
+                },
             })
         })
 
-        it("should use correct position", () => {
-            const row = { user_id: 1, name: "Test" }
-            const result = serializeScore(row, 5)
-            expect(result.pos).toBe(5)
+        it("should not include 'o' field when no opponent", () => {
+            const row = {
+                user_id: 123,
+                name: "Winner",
+                score: 5500,
+                time_spent_ms: 60000,
+                game_type: 3,
+                opponent_id: null,
+            }
+
+            const result = serializeScore(row)
+
+            expect(result.o).toBeUndefined()
+            expect("o" in result).toBe(false)
+        })
+
+        it("should handle missing optional fields", () => {
+            const row = {
+                user_id: 123,
+                name: "Player",
+                score: 5000,
+            }
+
+            const result = serializeScore(row)
+
+            expect(result.u.fc).toBe(0)
+            expect(result.u.rk).toBe(0)
+            expect(result.u.id).toBe("")
+        })
+    })
+
+    describe("serializeStarEntry", () => {
+        it("should serialize star ranking entry with all fields", () => {
+            const row = {
+                id: 123,
+                name: "StarPlayer",
+                uuid: "star-uuid",
+                rank: 7,
+                stars: 5000,
+                face: 3,
+                games: 200,
+                gameswon: 150,
+                games_android: 50,
+                games_bluetooth: 30,
+                games_web: 100,
+                games_passplay: 20,
+                wins_android: 40,
+                wins_bluetooth: 25,
+                wins_web: 75,
+                wins_passplay: 10,
+            }
+
+            const result = serializeStarEntry(row)
+
+            expect(result.type).toBe("Score")
+            expect(result.score).toBe(5000)
+            expect(result.u.nam).toBe("StarPlayer")
+            expect(result.u.i).toBe(123)
+            expect(result.u.rk).toBe(7)
+            expect(result.u.st).toBe(5000)
+            expect(result.u.pld).toBe(200)
+            expect(result.u.won).toBe(150)
+            expect(result.u.ga).toEqual([50, 30, 100, 20])
+            expect(result.u.wa).toEqual([40, 25, 75, 10])
+            expect(result.o).toBeUndefined()
+            expect("o" in result).toBe(false)
+        })
+
+        it("should handle missing optional fields", () => {
+            const row = {
+                id: 1,
+                name: "Player",
+            }
+
+            const result = serializeStarEntry(row)
+
+            expect(result.score).toBe(0)
+            expect(result.u.st).toBe(0)
+            expect(result.u.ga).toEqual([0, 0, 0, 0])
+            expect(result.u.wa).toEqual([0, 0, 0, 0])
         })
     })
 
@@ -63,66 +185,61 @@ describe("services/navalclash/leaderboardService", () => {
             mockRes.json.mockClear()
         })
 
-        it("should return top scores with default parameters", async () => {
-            mockExecute.mockResolvedValueOnce([
-                [
-                    { user_id: 1, name: "Player1", face: 1, uuid: "u1", score: 1500, time_spent_ms: 60000 },
-                    { user_id: 2, name: "Player2", face: 2, uuid: "u2", score: 1200, time_spent_ms: 70000 },
-                ],
-            ])
+        it("should return top scores without game type filter", async () => {
+            const mockScores = [
+                {
+                    user_id: 1,
+                    name: "Player1",
+                    score: 6000,
+                    game_type: 3,
+                    time_spent_ms: 60000,
+                },
+                {
+                    user_id: 2,
+                    name: "Player2",
+                    score: 5500,
+                    game_type: 3,
+                    time_spent_ms: 70000,
+                },
+            ]
+            dbGetTopScores.mockResolvedValue(mockScores)
+
+            const req = { requestId: "test", body: { var: 1 } }
+            await getTopScores(req, mockRes)
+
+            expect(dbGetTopScores).toHaveBeenCalledWith(1, 50)
+            expect(dbGetTopScoresByType).not.toHaveBeenCalled()
+
+            const response = mockRes.json.mock.calls[0][0]
+            expect(response.type).toBe("topTen")
+            expect(response.var).toBe(1)
+            expect(response.scores).toHaveLength(2)
+            expect(response.scores[0].score).toBe(6000)
+        })
+
+        it("should filter by game type when provided", async () => {
+            dbGetTopScoresByType.mockResolvedValue([])
+
+            const req = { requestId: "test", body: { var: 1, tp: 3 } }
+            await getTopScores(req, mockRes)
+
+            expect(dbGetTopScoresByType).toHaveBeenCalledWith(1, 3, 50)
+            expect(dbGetTopScores).not.toHaveBeenCalled()
+        })
+
+        it("should use default game variant 1", async () => {
+            dbGetTopScores.mockResolvedValue([])
 
             const req = { requestId: "test", body: {} }
-
             await getTopScores(req, mockRes)
 
-            expect(mockExecute).toHaveBeenCalledWith(
-                expect.stringContaining("FROM topscores"),
-                [1, 3, 10] // default gameVariant=1, gameType=3, limit=10
-            )
-            const response = mockRes.json.mock.calls[0][0]
-            expect(response.type).toBe("top")
-            expect(response.list).toHaveLength(2)
-            expect(response.list[0].pos).toBe(1)
-            expect(response.list[1].pos).toBe(2)
-        })
-
-        it("should use custom game variant and type", async () => {
-            mockExecute.mockResolvedValueOnce([[]])
-
-            const req = {
-                requestId: "test",
-                body: { var: 2, tp: 1, limit: 20 },
-            }
-
-            await getTopScores(req, mockRes)
-
-            expect(mockExecute).toHaveBeenCalledWith(
-                expect.anything(),
-                [2, 1, 20]
-            )
-        })
-
-        it("should cap limit at 50", async () => {
-            mockExecute.mockResolvedValueOnce([[]])
-
-            const req = {
-                requestId: "test",
-                body: { limit: 100 },
-            }
-
-            await getTopScores(req, mockRes)
-
-            expect(mockExecute).toHaveBeenCalledWith(
-                expect.anything(),
-                [1, 3, 50]
-            )
+            expect(dbGetTopScores).toHaveBeenCalledWith(1, 50)
         })
 
         it("should handle database error", async () => {
-            mockExecute.mockRejectedValueOnce(new Error("DB error"))
+            dbGetTopScores.mockRejectedValue(new Error("DB error"))
 
             const req = { requestId: "test", body: {} }
-
             await getTopScores(req, mockRes)
 
             expect(mockRes.json).toHaveBeenCalledWith({
@@ -130,29 +247,256 @@ describe("services/navalclash/leaderboardService", () => {
                 reason: "Database error",
             })
         })
+
+        it("should process client scores with existing user", async () => {
+            dbGetTopScores.mockResolvedValue([])
+            dbFindUserByUuidAndName.mockResolvedValue({ id: 42, name: "TestPlayer", uuid: "test-uuid-12345" })
+            dbSubmitScore.mockResolvedValue({ success: true, scoreId: 999 })
+
+            const req = {
+                requestId: "test",
+                body: {
+                    var: 1,
+                    scores: [{
+                        score: 5000,
+                        time: 60000,
+                        gtype: 2, // web (client format)
+                        u: { id: "test-uuid-12345", nam: "TestPlayer", rk: 5 },
+                    }],
+                },
+            }
+            await getTopScores(req, mockRes)
+
+            expect(dbFindUserByUuidAndName).toHaveBeenCalledWith("test-uuid-12345", "TestPlayer")
+            expect(dbSubmitScore).toHaveBeenCalledWith(expect.objectContaining({
+                userId: 42,
+                score: 5000,
+                gameType: 3, // web (DB format: client 2 + 1 = 3)
+            }))
+        })
+
+        it("should create user when not found (like old Java server)", async () => {
+            dbGetTopScores.mockResolvedValue([])
+            dbFindUserByUuidAndName.mockResolvedValue(null) // Not found by uuid+name
+            dbFindUserByUuid.mockResolvedValue(null) // Not found by uuid only
+            dbCreateUser.mockResolvedValue(123) // New user created with ID 123
+            dbSubmitScore.mockResolvedValue({ success: true, scoreId: 999 })
+
+            const req = {
+                requestId: "test",
+                body: {
+                    var: 1,
+                    scores: [{
+                        score: 5000,
+                        time: 60000,
+                        gtype: 0, // android (client format)
+                        u: { id: "new-user-uuid-12345", nam: "NewPlayer", rk: 3 },
+                    }],
+                },
+            }
+            await getTopScores(req, mockRes)
+
+            expect(dbCreateUser).toHaveBeenCalledWith({
+                name: "NewPlayer",
+                uuid: "new-user-uuid-12345",
+                gameVariant: 1,
+            })
+            expect(dbSubmitScore).toHaveBeenCalledWith(expect.objectContaining({
+                userId: 123,
+                score: 5000,
+                gameType: 1, // android (DB format: client 0 + 1 = 1)
+            }))
+        })
+
+        it("should create opponent when not found", async () => {
+            dbGetTopScores.mockResolvedValue([])
+            // User exists
+            dbFindUserByUuidAndName
+                .mockResolvedValueOnce({ id: 42, name: "Winner", uuid: "winner-uuid-12345" })
+                .mockResolvedValueOnce(null) // Opponent not found by uuid+name
+            dbFindUserByUuid.mockResolvedValue(null) // Opponent not found by uuid only
+            dbCreateUser.mockResolvedValue(99) // Opponent created with ID 99
+            dbSubmitScore.mockResolvedValue({ success: true, scoreId: 999 })
+
+            const req = {
+                requestId: "test",
+                body: {
+                    var: 1,
+                    scores: [{
+                        score: 5000,
+                        time: 60000,
+                        gtype: 2,
+                        u: { id: "winner-uuid-12345", nam: "Winner", rk: 5 },
+                        o: { id: "opponent-uuid-12345", nam: "Opponent", rk: 3 },
+                    }],
+                },
+            }
+            await getTopScores(req, mockRes)
+
+            expect(dbCreateUser).toHaveBeenCalledWith({
+                name: "Opponent",
+                uuid: "opponent-uuid-12345",
+                gameVariant: 1,
+            })
+            expect(dbSubmitScore).toHaveBeenCalledWith(expect.objectContaining({
+                userId: 42,
+                opponentId: 99,
+            }))
+        })
+
+        it("should skip scores with invalid UUIDs", async () => {
+            dbGetTopScores.mockResolvedValue([])
+
+            const req = {
+                requestId: "test",
+                body: {
+                    var: 1,
+                    scores: [
+                        { score: 5000, time: 60000, u: { id: "android", nam: "Test" } },
+                        { score: 5000, time: 60000, u: { id: "null", nam: "Test" } },
+                        { score: 5000, time: 60000, u: { id: "short", nam: "Test" } },
+                    ],
+                },
+            }
+            await getTopScores(req, mockRes)
+
+            expect(dbFindUserByUuidAndName).not.toHaveBeenCalled()
+            expect(dbSubmitScore).not.toHaveBeenCalled()
+        })
+
+        it("should include topstars for clients with version > 30", async () => {
+            dbGetTopScores.mockResolvedValue([])
+            dbGetTopStars.mockResolvedValue([
+                { id: 1, name: "StarPlayer", stars: 5000, rank: 7 },
+            ])
+
+            const req = {
+                requestId: "test",
+                body: { var: 1, v: 31 }, // Version > 30
+            }
+            await getTopScores(req, mockRes)
+
+            expect(dbGetTopStars).toHaveBeenCalledWith(1, 50)
+            const response = mockRes.json.mock.calls[0][0]
+            expect(response.topstars).toBeDefined()
+            expect(response.topstars.type).toBe("topTen")
+            expect(response.topstars.scores).toHaveLength(1)
+            expect(response.topstars.scores[0].u.nam).toBe("StarPlayer")
+        })
+
+        it("should NOT include topstars for clients with version <= 30", async () => {
+            dbGetTopScores.mockResolvedValue([])
+
+            const req = {
+                requestId: "test",
+                body: { var: 1, v: 30 }, // Version = 30 (not > 30)
+            }
+            await getTopScores(req, mockRes)
+
+            expect(dbGetTopStars).not.toHaveBeenCalled()
+            const response = mockRes.json.mock.calls[0][0]
+            expect(response.topstars).toBeUndefined()
+        })
+
+        it("should NOT include topstars when version not provided", async () => {
+            dbGetTopScores.mockResolvedValue([])
+
+            const req = {
+                requestId: "test",
+                body: { var: 1 }, // No version
+            }
+            await getTopScores(req, mockRes)
+
+            expect(dbGetTopStars).not.toHaveBeenCalled()
+            const response = mockRes.json.mock.calls[0][0]
+            expect(response.topstars).toBeUndefined()
+        })
     })
 
     describe("submitScore", () => {
-        it("should submit score and return insertId", async () => {
-            mockExecute.mockResolvedValueOnce([{ insertId: 42 }])
+        it("should submit score and return result", async () => {
+            dbSubmitScore.mockResolvedValue({ success: true, scoreId: 42 })
 
             const ctx = { reqId: "test" }
-            const result = await submitScore(1, 2, 1500, 60000, 3, 1, 10, 8, ctx)
-
-            expect(result).toBe(42)
-            expect(mockExecute).toHaveBeenCalledWith(
-                expect.stringContaining("INSERT INTO topscores"),
-                [1, 2, 1500, 60000, 3, 1, 10, 8]
+            const result = await submitScore(
+                1,
+                2,
+                5000,
+                60000,
+                3,
+                1,
+                5,
+                4,
+                ctx
             )
+
+            expect(result).toEqual({ success: true, scoreId: 42 })
+            expect(dbSubmitScore).toHaveBeenCalledWith({
+                userId: 1,
+                opponentId: 2,
+                score: 5000,
+                timeMs: 60000,
+                gameType: 3,
+                gameVariant: 1,
+                userRank: 5,
+                opponentRank: 4,
+            })
         })
 
-        it("should return null on error", async () => {
-            mockExecute.mockRejectedValueOnce(new Error("DB error"))
+        it("should return failure result when validation fails", async () => {
+            dbSubmitScore.mockResolvedValue({
+                success: false,
+                reason: "Score below threshold",
+            })
 
             const ctx = { reqId: "test" }
-            const result = await submitScore(1, 2, 1500, 60000, 3, 1, 10, 8, ctx)
+            const result = await submitScore(
+                1,
+                2,
+                2000, // Below threshold
+                60000,
+                3,
+                1,
+                5,
+                4,
+                ctx
+            )
+
+            expect(result.success).toBe(false)
+            expect(result.reason).toContain("threshold")
+        })
+    })
+
+    describe("getUserLeaderboardRank", () => {
+        it("should return user's leaderboard rank", async () => {
+            dbGetUserLeaderboardRank.mockResolvedValue(5)
+
+            const result = await getUserLeaderboardRank(123, 1)
+
+            expect(result).toBe(5)
+            expect(dbGetUserLeaderboardRank).toHaveBeenCalledWith(123, 1)
+        })
+
+        it("should return null if user not ranked", async () => {
+            dbGetUserLeaderboardRank.mockResolvedValue(null)
+
+            const result = await getUserLeaderboardRank(999, 1)
 
             expect(result).toBeNull()
+        })
+    })
+
+    describe("constants", () => {
+        it("should export TOPSCORE_THRESHOLD", () => {
+            expect(TOPSCORE_THRESHOLD).toBe(3000)
+        })
+
+        it("should export MIN_GAME_TIME_MS", () => {
+            expect(MIN_GAME_TIME_MS).toBe(30000)
+        })
+
+        it("should export TOPSTARS_MIN_VERSION as 30", () => {
+            expect(TOPSTARS_MIN_VERSION).toBe(30)
         })
     })
 })

--- a/services/navalclash/leaderboardService.test.js
+++ b/services/navalclash/leaderboardService.test.js
@@ -45,8 +45,9 @@ const {
     serializeStarEntry,
     TOPSCORE_THRESHOLD,
     MIN_GAME_TIME_MS,
-    TOPSTARS_MIN_VERSION,
 } = require("./leaderboardService")
+
+const { VERSION } = require("./constants")
 
 describe("services/navalclash/leaderboardService", () => {
     beforeEach(() => {
@@ -495,8 +496,8 @@ describe("services/navalclash/leaderboardService", () => {
             expect(MIN_GAME_TIME_MS).toBe(30000)
         })
 
-        it("should export TOPSTARS_MIN_VERSION as 30", () => {
-            expect(TOPSTARS_MIN_VERSION).toBe(30)
+        it("VERSION.TOPSTARS_MIN should be 30", () => {
+            expect(VERSION.TOPSTARS_MIN).toBe(30)
         })
     })
 })

--- a/services/navalclash/leaderboardService.test.js
+++ b/services/navalclash/leaderboardService.test.js
@@ -251,29 +251,44 @@ describe("services/navalclash/leaderboardService", () => {
 
         it("should process client scores with existing user", async () => {
             dbGetTopScores.mockResolvedValue([])
-            dbFindUserByUuidAndName.mockResolvedValue({ id: 42, name: "TestPlayer", uuid: "test-uuid-12345" })
+            dbFindUserByUuidAndName.mockResolvedValue({
+                id: 42,
+                name: "TestPlayer",
+                uuid: "test-uuid-12345",
+            })
             dbSubmitScore.mockResolvedValue({ success: true, scoreId: 999 })
 
             const req = {
                 requestId: "test",
                 body: {
                     var: 1,
-                    scores: [{
-                        score: 5000,
-                        time: 60000,
-                        gtype: 2, // web (client format)
-                        u: { id: "test-uuid-12345", nam: "TestPlayer", rk: 5 },
-                    }],
+                    scores: [
+                        {
+                            score: 5000,
+                            time: 60000,
+                            gtype: 2, // web (client format)
+                            u: {
+                                id: "test-uuid-12345",
+                                nam: "TestPlayer",
+                                rk: 5,
+                            },
+                        },
+                    ],
                 },
             }
             await getTopScores(req, mockRes)
 
-            expect(dbFindUserByUuidAndName).toHaveBeenCalledWith("test-uuid-12345", "TestPlayer")
-            expect(dbSubmitScore).toHaveBeenCalledWith(expect.objectContaining({
-                userId: 42,
-                score: 5000,
-                gameType: 3, // web (DB format: client 2 + 1 = 3)
-            }))
+            expect(dbFindUserByUuidAndName).toHaveBeenCalledWith(
+                "test-uuid-12345",
+                "TestPlayer"
+            )
+            expect(dbSubmitScore).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 42,
+                    score: 5000,
+                    gameType: 3, // web (DB format: client 2 + 1 = 3)
+                })
+            )
         })
 
         it("should create user when not found (like old Java server)", async () => {
@@ -287,12 +302,18 @@ describe("services/navalclash/leaderboardService", () => {
                 requestId: "test",
                 body: {
                     var: 1,
-                    scores: [{
-                        score: 5000,
-                        time: 60000,
-                        gtype: 0, // android (client format)
-                        u: { id: "new-user-uuid-12345", nam: "NewPlayer", rk: 3 },
-                    }],
+                    scores: [
+                        {
+                            score: 5000,
+                            time: 60000,
+                            gtype: 0, // android (client format)
+                            u: {
+                                id: "new-user-uuid-12345",
+                                nam: "NewPlayer",
+                                rk: 3,
+                            },
+                        },
+                    ],
                 },
             }
             await getTopScores(req, mockRes)
@@ -302,18 +323,24 @@ describe("services/navalclash/leaderboardService", () => {
                 uuid: "new-user-uuid-12345",
                 gameVariant: 1,
             })
-            expect(dbSubmitScore).toHaveBeenCalledWith(expect.objectContaining({
-                userId: 123,
-                score: 5000,
-                gameType: 1, // android (DB format: client 0 + 1 = 1)
-            }))
+            expect(dbSubmitScore).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 123,
+                    score: 5000,
+                    gameType: 1, // android (DB format: client 0 + 1 = 1)
+                })
+            )
         })
 
         it("should create opponent when not found", async () => {
             dbGetTopScores.mockResolvedValue([])
             // User exists
             dbFindUserByUuidAndName
-                .mockResolvedValueOnce({ id: 42, name: "Winner", uuid: "winner-uuid-12345" })
+                .mockResolvedValueOnce({
+                    id: 42,
+                    name: "Winner",
+                    uuid: "winner-uuid-12345",
+                })
                 .mockResolvedValueOnce(null) // Opponent not found by uuid+name
             dbFindUserByUuid.mockResolvedValue(null) // Opponent not found by uuid only
             dbCreateUser.mockResolvedValue(99) // Opponent created with ID 99
@@ -323,13 +350,23 @@ describe("services/navalclash/leaderboardService", () => {
                 requestId: "test",
                 body: {
                     var: 1,
-                    scores: [{
-                        score: 5000,
-                        time: 60000,
-                        gtype: 2,
-                        u: { id: "winner-uuid-12345", nam: "Winner", rk: 5 },
-                        o: { id: "opponent-uuid-12345", nam: "Opponent", rk: 3 },
-                    }],
+                    scores: [
+                        {
+                            score: 5000,
+                            time: 60000,
+                            gtype: 2,
+                            u: {
+                                id: "winner-uuid-12345",
+                                nam: "Winner",
+                                rk: 5,
+                            },
+                            o: {
+                                id: "opponent-uuid-12345",
+                                nam: "Opponent",
+                                rk: 3,
+                            },
+                        },
+                    ],
                 },
             }
             await getTopScores(req, mockRes)
@@ -339,10 +376,12 @@ describe("services/navalclash/leaderboardService", () => {
                 uuid: "opponent-uuid-12345",
                 gameVariant: 1,
             })
-            expect(dbSubmitScore).toHaveBeenCalledWith(expect.objectContaining({
-                userId: 42,
-                opponentId: 99,
-            }))
+            expect(dbSubmitScore).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 42,
+                    opponentId: 99,
+                })
+            )
         })
 
         it("should skip scores with invalid UUIDs", async () => {
@@ -353,9 +392,21 @@ describe("services/navalclash/leaderboardService", () => {
                 body: {
                     var: 1,
                     scores: [
-                        { score: 5000, time: 60000, u: { id: "android", nam: "Test" } },
-                        { score: 5000, time: 60000, u: { id: "null", nam: "Test" } },
-                        { score: 5000, time: 60000, u: { id: "short", nam: "Test" } },
+                        {
+                            score: 5000,
+                            time: 60000,
+                            u: { id: "android", nam: "Test" },
+                        },
+                        {
+                            score: 5000,
+                            time: 60000,
+                            u: { id: "null", nam: "Test" },
+                        },
+                        {
+                            score: 5000,
+                            time: 60000,
+                            u: { id: "short", nam: "Test" },
+                        },
                     ],
                 },
             }
@@ -419,17 +470,7 @@ describe("services/navalclash/leaderboardService", () => {
             dbSubmitScore.mockResolvedValue({ success: true, scoreId: 42 })
 
             const ctx = { reqId: "test" }
-            const result = await submitScore(
-                1,
-                2,
-                5000,
-                60000,
-                3,
-                1,
-                5,
-                4,
-                ctx
-            )
+            const result = await submitScore(1, 2, 5000, 60000, 3, 1, 5, 4, ctx)
 
             expect(result).toEqual({ success: true, scoreId: 42 })
             expect(dbSubmitScore).toHaveBeenCalledWith({

--- a/services/navalclash/messageService.js
+++ b/services/navalclash/messageService.js
@@ -8,13 +8,9 @@ const { pool } = require("../../db/navalclash")
 const cluster = require("cluster")
 const { v4: uuid } = require("uuid")
 const { logger } = require("../../utils/logger")
+const { TIMING } = require("./constants")
 
 const pendingPolls = new Map()
-
-/**
- * Default long-poll timeout in milliseconds.
- */
-const POLL_TIMEOUT_MS = 30000
 
 /**
  * Computes opponent's session ID by flipping the last bit.
@@ -239,7 +235,7 @@ function setupLongPoll(res, sessionId, afterMsgId, clientPollId, requestId) {
             }
             pollData.res.json({ type: "empty" })
         }
-    }, POLL_TIMEOUT_MS)
+    }, TIMING.POLL_TIMEOUT_MS)
 
     pendingPolls.set(requestId, {
         res,
@@ -446,5 +442,4 @@ module.exports = {
     // Exported for testing
     handleWake,
     handleCancel,
-    POLL_TIMEOUT_MS,
 }

--- a/services/navalclash/messageService.js
+++ b/services/navalclash/messageService.js
@@ -313,18 +313,15 @@ async function poll(req, res) {
         }
 
         // No message available, set up long poll
-        setupLongPoll(
-            res,
-            sessionId,
-            afterMsgId,
-            clientPollId,
-            requestId
-        )
+        setupLongPoll(res, sessionId, afterMsgId, clientPollId, requestId)
 
         // Race condition check - message might have arrived while setting up
         const raceCheck = await fetchNextMessage(sessionId, afterMsgId)
         if (raceCheck && pendingPolls.has(requestId)) {
-            logger.debug(ctx, "Race condition detected, message arrived during setup")
+            logger.debug(
+                ctx,
+                "Race condition detected, message arrived during setup"
+            )
             fetchAndRespond(pendingPolls.get(requestId))
         }
     } catch (error) {
@@ -387,7 +384,10 @@ async function send(req, res) {
     }
 
     if (!msgType) {
-        logger.warn({ reqId: requestId, sid }, "Send request missing message type")
+        logger.warn(
+            { reqId: requestId, sid },
+            "Send request missing message type"
+        )
         return res.json({ type: "error", reason: "No message type" })
     }
 

--- a/services/navalclash/messageService.js
+++ b/services/navalclash/messageService.js
@@ -4,11 +4,16 @@
  * All rights reserved.
  */
 
-const { pool } = require("../../db/navalclash")
+const {
+    pool,
+    dbUpdatePlayerLastSeen,
+    dbGetOpponentLastSeen,
+    dbCloseStaleSession,
+} = require("../../db/navalclash")
 const cluster = require("cluster")
 const { v4: uuid } = require("uuid")
 const { logger } = require("../../utils/logger")
-const { TIMING } = require("./constants")
+const { TIMING, SESSION_STATUS, MSG } = require("./constants")
 
 const pendingPolls = new Map()
 
@@ -260,6 +265,61 @@ function setupLongPoll(res, sessionId, afterMsgId, clientPollId, requestId) {
 }
 
 /**
+ * Checks if the opponent is dead (not polling) in an IN_PROGRESS session.
+ * If the opponent's last_seen exceeds SESSION_ALIVE_MS, closes the session
+ * and returns a response payload for the polling player.
+ *
+ * @param {BigInt} baseSessionId - Base session ID (even)
+ * @param {number} player - Current player number (0 or 1)
+ * @param {Object} ctx - Logging context
+ * @returns {Promise<Object|null>} Response payload if opponent is dead, null otherwise
+ */
+async function checkDeadOpponent(baseSessionId, player, ctx) {
+    const sessionInfo = await dbGetOpponentLastSeen(baseSessionId, player)
+    if (!sessionInfo || sessionInfo.status !== SESSION_STATUS.IN_PROGRESS) {
+        return null
+    }
+
+    const opponentLastSeen = sessionInfo.opponent_last_seen
+    if (!opponentLastSeen) {
+        // Opponent never polled (just joined) — give them time
+        return null
+    }
+
+    const elapsed = Date.now() - new Date(opponentLastSeen).getTime()
+    if (elapsed <= TIMING.SESSION_ALIVE_MS) {
+        return null
+    }
+
+    // Opponent is dead — close the session
+    logger.info(
+        { ...ctx, elapsed, threshold: TIMING.SESSION_ALIVE_MS },
+        "Dead opponent detected during poll, closing session"
+    )
+
+    const affected = await dbCloseStaleSession(
+        baseSessionId,
+        SESSION_STATUS.FINISHED_NOT_PINGABLE
+    )
+
+    if (affected === 0) {
+        // Session was already closed by another path
+        return null
+    }
+
+    // Return a "left" info message so the client knows the opponent left
+    return {
+        type: "info",
+        msg: {
+            type: "msg",
+            m: MSG.LEFT_SCREEN,
+            p: ["self"],
+            c: false,
+        },
+    }
+}
+
+/**
  * Poll endpoint - long-polls for messages.
  * Session ID already contains player info in last bit.
  *
@@ -284,12 +344,11 @@ async function poll(req, res) {
     logger.debug({ ...ctx, after: afterMsgId }, "Poll request received")
 
     try {
-        // Keep session alive - update updated_at so matchmaking can find waiting sessions
-        await pool.execute(
-            `UPDATE game_sessions SET updated_at = NOW(3)
-             WHERE id = ? AND status = 0`,
-            [toBaseSessionId(sessionId).toString()]
-        )
+        const baseSessionId = toBaseSessionId(sessionId)
+        const player = Number(sessionId & 1n)
+
+        // Update per-player last_seen (also refreshes updated_at via ON UPDATE)
+        await dbUpdatePlayerLastSeen(baseSessionId, player)
 
         // Acknowledge previously received messages
         if (afterMsgId > 0n) {
@@ -310,6 +369,16 @@ async function poll(req, res) {
                 msgId: message.msg_id.toString(),
                 ...message.body,
             })
+        }
+
+        // No message — check if opponent is dead (IN_PROGRESS sessions only)
+        const deadOpponent = await checkDeadOpponent(
+            baseSessionId,
+            player,
+            ctx
+        )
+        if (deadOpponent) {
+            return res.json(deadOpponent)
         }
 
         // No message available, set up long poll
@@ -395,6 +464,12 @@ async function send(req, res) {
 
     try {
         const sessionId = BigInt(sid)
+        const baseSessionId = sessionId & ~1n
+        const player = Number(sessionId & 1n)
+
+        // Update sender's last_seen (also refreshes updated_at)
+        await dbUpdatePlayerLastSeen(baseSessionId, player)
+
         const msgId = await sendMessage(sessionId, msgType, body)
 
         logger.info({ ...ctx, msgId }, `Message ${msgType} sent successfully`)
@@ -442,4 +517,5 @@ module.exports = {
     // Exported for testing
     handleWake,
     handleCancel,
+    checkDeadOpponent,
 }

--- a/services/navalclash/messageService.js
+++ b/services/navalclash/messageService.js
@@ -276,7 +276,21 @@ function setupLongPoll(res, sessionId, afterMsgId, clientPollId, requestId) {
  */
 async function checkDeadOpponent(baseSessionId, player, ctx) {
     const sessionInfo = await dbGetOpponentLastSeen(baseSessionId, player)
-    if (!sessionInfo || sessionInfo.status !== SESSION_STATUS.IN_PROGRESS) {
+    if (!sessionInfo) {
+        return null
+    }
+
+    // Session already closed — tell client to stop polling and reconnect
+    if (sessionInfo.status > SESSION_STATUS.IN_PROGRESS) {
+        logger.info(
+            { ...ctx, status: sessionInfo.status },
+            "Session closed, sending errcode 5 to trigger client reconnect"
+        )
+        return { type: "error", errcode: 5, reason: "Session terminated" }
+    }
+
+    // Not yet in progress (WAITING) — keep polling normally
+    if (sessionInfo.status !== SESSION_STATUS.IN_PROGRESS) {
         return null
     }
 

--- a/services/navalclash/messageService.test.js
+++ b/services/navalclash/messageService.test.js
@@ -160,7 +160,9 @@ describe("services/navalclash/messageService", () => {
                 msg_type: "greeting",
                 body: JSON.stringify({ u: { name: "Test" } }),
             }
-            mockExecute.mockResolvedValueOnce([[mockMessage]])
+            mockExecute
+                .mockResolvedValueOnce([{ affectedRows: 1 }]) // UPDATE game_sessions
+                .mockResolvedValueOnce([[mockMessage]]) // fetch message
 
             const req = { body: { sid: "1001" } }
 
@@ -175,6 +177,7 @@ describe("services/navalclash/messageService", () => {
 
         it("should delete acknowledged messages if after is provided", async () => {
             mockExecute
+                .mockResolvedValueOnce([{ affectedRows: 1 }]) // UPDATE game_sessions
                 .mockResolvedValueOnce([{ affectedRows: 2 }]) // delete
                 .mockResolvedValueOnce([
                     [{ msg_id: 10, msg_type: "ok", body: "{}" }],

--- a/services/navalclash/messageService.test.js
+++ b/services/navalclash/messageService.test.js
@@ -5,11 +5,17 @@
  */
 
 const mockExecute = jest.fn()
+const mockDbUpdatePlayerLastSeen = jest.fn().mockResolvedValue(true)
+const mockDbGetOpponentLastSeen = jest.fn().mockResolvedValue(null)
+const mockDbCloseStaleSession = jest.fn().mockResolvedValue(0)
 
 jest.mock("../../db/navalclash", () => ({
     pool: {
         execute: mockExecute,
     },
+    dbUpdatePlayerLastSeen: (...args) => mockDbUpdatePlayerLastSeen(...args),
+    dbGetOpponentLastSeen: (...args) => mockDbGetOpponentLastSeen(...args),
+    dbCloseStaleSession: (...args) => mockDbCloseStaleSession(...args),
 }))
 
 jest.mock("cluster", () => ({
@@ -26,6 +32,7 @@ const {
     deleteAcknowledgedMessages,
     getPendingPollCount,
     clearPendingPolls,
+    checkDeadOpponent,
 } = require("./messageService")
 
 describe("services/navalclash/messageService", () => {
@@ -134,6 +141,86 @@ describe("services/navalclash/messageService", () => {
         })
     })
 
+    describe("checkDeadOpponent", () => {
+        it("should return null for non-IN_PROGRESS session", async () => {
+            mockDbGetOpponentLastSeen.mockResolvedValueOnce({
+                status: 0,
+                opponent_last_seen: null,
+            })
+
+            const result = await checkDeadOpponent(1000n, 0, {})
+
+            expect(result).toBeNull()
+        })
+
+        it("should return null when opponent never polled (just joined)", async () => {
+            mockDbGetOpponentLastSeen.mockResolvedValueOnce({
+                status: 1,
+                opponent_last_seen: null,
+                user_one_id: 1,
+                user_two_id: 2,
+            })
+
+            const result = await checkDeadOpponent(1000n, 0, {})
+
+            expect(result).toBeNull()
+        })
+
+        it("should return null when opponent is alive", async () => {
+            mockDbGetOpponentLastSeen.mockResolvedValueOnce({
+                status: 1,
+                opponent_last_seen: new Date(), // Just now
+                user_one_id: 1,
+                user_two_id: 2,
+            })
+
+            const result = await checkDeadOpponent(1000n, 0, {})
+
+            expect(result).toBeNull()
+        })
+
+        it("should close session and return left message when opponent is dead", async () => {
+            const staleTime = new Date(Date.now() - 60000) // 60 seconds ago
+            mockDbGetOpponentLastSeen.mockResolvedValueOnce({
+                status: 1,
+                opponent_last_seen: staleTime,
+                user_one_id: 1,
+                user_two_id: 2,
+            })
+            mockDbCloseStaleSession.mockResolvedValueOnce(1)
+
+            const result = await checkDeadOpponent(1000n, 0, {})
+
+            expect(result).toBeTruthy()
+            expect(result.type).toBe("info")
+            expect(result.msg.m).toBe(5) // MSG.LEFT_SCREEN
+            expect(mockDbCloseStaleSession).toHaveBeenCalledWith(1000n, 9) // FINISHED_NOT_PINGABLE
+        })
+
+        it("should return null when session already closed by another path", async () => {
+            const staleTime = new Date(Date.now() - 60000)
+            mockDbGetOpponentLastSeen.mockResolvedValueOnce({
+                status: 1,
+                opponent_last_seen: staleTime,
+                user_one_id: 1,
+                user_two_id: 2,
+            })
+            mockDbCloseStaleSession.mockResolvedValueOnce(0) // Already closed
+
+            const result = await checkDeadOpponent(1000n, 0, {})
+
+            expect(result).toBeNull()
+        })
+
+        it("should return null when session not found", async () => {
+            mockDbGetOpponentLastSeen.mockResolvedValueOnce(null)
+
+            const result = await checkDeadOpponent(9999n, 0, {})
+
+            expect(result).toBeNull()
+        })
+    })
+
     describe("poll", () => {
         const mockRes = {
             json: jest.fn(),
@@ -154,15 +241,32 @@ describe("services/navalclash/messageService", () => {
             })
         })
 
+        it("should update player last_seen on each poll", async () => {
+            const mockMessage = {
+                msg_id: 5,
+                msg_type: "greeting",
+                body: JSON.stringify({ u: { name: "Test" } }),
+            }
+            mockExecute.mockResolvedValueOnce([[mockMessage]]) // fetch message
+
+            const req = { body: { sid: "1001" } }
+
+            await poll(req, mockRes)
+
+            // Player 1 (odd session ID), base session = 1000
+            expect(mockDbUpdatePlayerLastSeen).toHaveBeenCalledWith(
+                1000n,
+                1
+            )
+        })
+
         it("should return message immediately if available", async () => {
             const mockMessage = {
                 msg_id: 5,
                 msg_type: "greeting",
                 body: JSON.stringify({ u: { name: "Test" } }),
             }
-            mockExecute
-                .mockResolvedValueOnce([{ affectedRows: 1 }]) // UPDATE game_sessions
-                .mockResolvedValueOnce([[mockMessage]]) // fetch message
+            mockExecute.mockResolvedValueOnce([[mockMessage]]) // fetch message
 
             const req = { body: { sid: "1001" } }
 
@@ -175,9 +279,31 @@ describe("services/navalclash/messageService", () => {
             })
         })
 
+        it("should check for dead opponent when no message available", async () => {
+            // No message available
+            mockExecute.mockResolvedValueOnce([[]]) // fetch message - empty
+            mockDbGetOpponentLastSeen.mockResolvedValueOnce({
+                status: 1,
+                opponent_last_seen: new Date(Date.now() - 60000), // 60s ago
+                user_one_id: 1,
+                user_two_id: 2,
+            })
+            mockDbCloseStaleSession.mockResolvedValueOnce(1)
+
+            const req = { body: { sid: "1001" } }
+
+            await poll(req, mockRes)
+
+            expect(mockRes.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "info",
+                    msg: expect.objectContaining({ m: 5 }),
+                })
+            )
+        })
+
         it("should delete acknowledged messages if after is provided", async () => {
             mockExecute
-                .mockResolvedValueOnce([{ affectedRows: 1 }]) // UPDATE game_sessions
                 .mockResolvedValueOnce([{ affectedRows: 2 }]) // delete
                 .mockResolvedValueOnce([
                     [{ msg_id: 10, msg_type: "ok", body: "{}" }],
@@ -194,7 +320,9 @@ describe("services/navalclash/messageService", () => {
         })
 
         it("should handle database errors", async () => {
-            mockExecute.mockRejectedValueOnce(new Error("DB error"))
+            mockDbUpdatePlayerLastSeen.mockRejectedValueOnce(
+                new Error("DB error")
+            )
 
             const req = { body: { sid: "1001" } }
 
@@ -238,6 +366,26 @@ describe("services/navalclash/messageService", () => {
             })
         })
 
+        it("should update player last_seen on send", async () => {
+            mockExecute.mockResolvedValueOnce([{ insertId: 123 }])
+
+            const req = {
+                body: {
+                    sid: "1000",
+                    msgType: "greeting",
+                    u: { name: "Player" },
+                },
+            }
+
+            await send(req, mockRes)
+
+            // Player 0 (even session ID), base session = 1000
+            expect(mockDbUpdatePlayerLastSeen).toHaveBeenCalledWith(
+                1000n,
+                0
+            )
+        })
+
         it("should send message and return ok with msgId", async () => {
             mockExecute.mockResolvedValueOnce([{ insertId: 123 }])
 
@@ -258,7 +406,9 @@ describe("services/navalclash/messageService", () => {
         })
 
         it("should handle database errors", async () => {
-            mockExecute.mockRejectedValueOnce(new Error("DB error"))
+            mockDbUpdatePlayerLastSeen.mockRejectedValueOnce(
+                new Error("DB error")
+            )
 
             const req = {
                 body: { sid: "1000", msgType: "greeting" },

--- a/services/navalclash/messageService.test.js
+++ b/services/navalclash/messageService.test.js
@@ -142,7 +142,7 @@ describe("services/navalclash/messageService", () => {
     })
 
     describe("checkDeadOpponent", () => {
-        it("should return null for non-IN_PROGRESS session", async () => {
+        it("should return null for WAITING session", async () => {
             mockDbGetOpponentLastSeen.mockResolvedValueOnce({
                 status: 0,
                 opponent_last_seen: null,
@@ -151,6 +151,36 @@ describe("services/navalclash/messageService", () => {
             const result = await checkDeadOpponent(1000n, 0, {})
 
             expect(result).toBeNull()
+        })
+
+        it("should return errcode 5 for closed session (FINISHED_NOT_PINGABLE)", async () => {
+            mockDbGetOpponentLastSeen.mockResolvedValueOnce({
+                status: 9, // FINISHED_NOT_PINGABLE
+                opponent_last_seen: null,
+            })
+
+            const result = await checkDeadOpponent(1000n, 0, {})
+
+            expect(result).toEqual({
+                type: "error",
+                errcode: 5,
+                reason: "Session terminated",
+            })
+        })
+
+        it("should return errcode 5 for closed session (FINISHED_OK)", async () => {
+            mockDbGetOpponentLastSeen.mockResolvedValueOnce({
+                status: 10, // FINISHED_OK
+                opponent_last_seen: null,
+            })
+
+            const result = await checkDeadOpponent(1000n, 0, {})
+
+            expect(result).toEqual({
+                type: "error",
+                errcode: 5,
+                reason: "Session terminated",
+            })
         })
 
         it("should return null when opponent never polled (just joined)", async () => {

--- a/services/navalclash/profileService.js
+++ b/services/navalclash/profileService.js
@@ -1,0 +1,248 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ */
+
+const {
+    pool,
+    dbFindUserByUuidAndName,
+    dbFindUserByNameAndPin,
+    dbUpdateUserProfile,
+    dbUpdateLocalStats,
+    dbLogProfileAction,
+} = require("../../db/navalclash")
+const { logger } = require("../../utils/logger")
+
+/**
+ * Generates a unique PIN for a user.
+ *
+ * @param {Object} conn - Database connection
+ * @param {string} name - Player name
+ * @returns {Promise<number>} Unique PIN
+ */
+async function generateUniquePin(conn, name) {
+    let pin
+    let attempts = 0
+    let maxPin = 9999
+
+    while (attempts < 100) {
+        pin = Math.floor(Math.random() * maxPin) + 1
+        const [rows] = await conn.execute(
+            "SELECT id FROM users WHERE name = ? AND pin = ?",
+            [name, pin]
+        )
+        if (rows.length === 0) return pin
+
+        attempts++
+        if (attempts % 10 === 0) maxPin *= 10
+    }
+    return pin
+}
+
+/**
+ * Serializes user object for export response.
+ * Format matches the client's PlayerInfo serialization.
+ *
+ * @param {Object} user - User object from database
+ * @returns {Object} Serialized user data for client
+ */
+function serializeUserForExport(user) {
+    return {
+        nam: user.name,
+        i: user.id,
+        pin: user.pin,
+        rk: user.rank || 0,
+        st: user.stars || 0,
+        won: user.gameswon || 0,
+        pld: user.games || 0,
+        fc: user.face || 0,
+        an: user.coins || 0,
+        l: user.lang || "en",
+        tz: user.tz || 0,
+        ga: [
+            user.games_android || 0,
+            user.games_bluetooth || 0,
+            user.games_web || 0,
+            user.games_passplay || 0,
+        ],
+        wa: [
+            user.wins_android || 0,
+            user.wins_bluetooth || 0,
+            user.wins_web || 0,
+            user.wins_passplay || 0,
+        ],
+    }
+}
+
+/**
+ * Export profile endpoint handler.
+ * Saves player data to server and returns a PIN for later recovery.
+ *
+ * @param {Object} req - Express request
+ * @param {Object} res - Express response
+ * @returns {Promise<void>}
+ */
+async function exportProfile(req, res) {
+    const body = req.body
+    const clientUser = body.u
+    const ctx = { type: "export" }
+
+    logger.info(ctx, "Export profile request received")
+
+    if (!clientUser || !clientUser.nam || !clientUser.id) {
+        logger.warn(ctx, "Invalid export request - missing user data")
+        return res.json({ type: "error", reason: "Invalid request" })
+    }
+
+    ctx.name = clientUser.nam
+    ctx.clientUid = clientUser.id
+
+    const conn = await pool.getConnection()
+    try {
+        await conn.beginTransaction()
+
+        // Find user by UUID + name (from client's id field which is device UUID)
+        let user = await dbFindUserByUuidAndName(clientUser.id, clientUser.nam)
+
+        if (!user) {
+            // User not found - try to find by name only and create if needed
+            logger.info(ctx, "User not found by UUID, creating new profile")
+
+            const pin = await generateUniquePin(conn, clientUser.nam)
+            const [result] = await conn.execute(
+                `INSERT INTO users (name, uuid, pin, face, lang, tz, coins, version)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+                [
+                    clientUser.nam,
+                    clientUser.id || "",
+                    pin,
+                    clientUser.fc || 0,
+                    clientUser.l || "en",
+                    clientUser.tz || 0,
+                    clientUser.an || 0,
+                    body.v || 0,
+                ]
+            )
+            const userId = result.insertId
+
+            const [rows] = await conn.execute(
+                "SELECT * FROM users WHERE id = ?",
+                [userId]
+            )
+            user = rows[0]
+            ctx.uid = userId
+            logger.info({ ...ctx, pin }, "New user created for export")
+        } else {
+            ctx.uid = user.id
+
+            // Generate PIN if user doesn't have one
+            if (!user.pin) {
+                const pin = await generateUniquePin(conn, user.name)
+                await conn.execute("UPDATE users SET pin = ? WHERE id = ?", [
+                    pin,
+                    user.id,
+                ])
+                user.pin = pin
+                logger.info({ ...ctx, pin }, "Generated new PIN for existing user")
+            }
+
+            // Update profile data from client
+            await dbUpdateUserProfile(conn, user.id, clientUser)
+
+            // Update local game stats
+            if (clientUser.ga && clientUser.wa) {
+                await dbUpdateLocalStats(conn, user.id, clientUser)
+            }
+
+            // Refresh user data
+            const [rows] = await conn.execute(
+                "SELECT * FROM users WHERE id = ?",
+                [user.id]
+            )
+            user = rows[0]
+            logger.info(ctx, "Updated existing user profile")
+        }
+
+        await conn.commit()
+
+        // Log the export action
+        dbLogProfileAction(
+            user.id,
+            "export",
+            `device=${clientUser.dev || "unknown"}`
+        )
+
+        logger.info({ ...ctx, pin: user.pin }, "Export successful")
+
+        return res.json({
+            type: "uexpres",
+            id: user.id,
+            pin: user.pin,
+            u: serializeUserForExport(user),
+        })
+    } catch (error) {
+        await conn.rollback()
+        logger.error(ctx, "Export failed:", error.message)
+        return res.json({ type: "error", reason: "Server error" })
+    } finally {
+        conn.release()
+    }
+}
+
+/**
+ * Import profile endpoint handler.
+ * Retrieves player profile using name + PIN verification.
+ *
+ * @param {Object} req - Express request
+ * @param {Object} res - Express response
+ * @returns {Promise<void>}
+ */
+async function importProfile(req, res) {
+    const body = req.body
+    const name = body.name
+    const pin = parseInt(body.pin, 10)
+    const ctx = { type: "import", name }
+
+    logger.info(ctx, "Import profile request received")
+
+    if (!name || !pin || isNaN(pin)) {
+        logger.warn(ctx, "Invalid import request - missing name or PIN")
+        return res.json({ type: "uimpres" })
+    }
+
+    try {
+        const user = await dbFindUserByNameAndPin(name, pin)
+
+        if (!user) {
+            logger.warn({ ...ctx, pin }, "Import failed - user not found")
+            return res.json({ type: "uimpres" })
+        }
+
+        ctx.uid = user.id
+
+        // Check if user is banned
+        if (user.isbanned) {
+            logger.warn(ctx, "Import failed - user is banned")
+            return res.json({ type: "uimpres" })
+        }
+
+        // Log the import action
+        dbLogProfileAction(user.id, "import", `v=${body.v || 0}`)
+
+        logger.info(ctx, "Import successful")
+
+        return res.json({
+            type: "uimpres",
+            u: serializeUserForExport(user),
+        })
+    } catch (error) {
+        logger.error(ctx, "Import failed:", error.message)
+        return res.json({ type: "uimpres" })
+    }
+}
+
+module.exports = {
+    exportProfile,
+    importProfile,
+}

--- a/services/navalclash/profileService.js
+++ b/services/navalclash/profileService.js
@@ -10,10 +10,10 @@ const {
     dbFindUserByUuid,
     dbFindUserByNameAndPin,
     dbCreateUser,
-    dbUpdateUserProfile,
     dbSyncUserProfile,
-    dbUpdateLocalStats,
+    dbUpdateProfileAndStats,
     dbLogProfileAction,
+    dbGetUserWeaponArrays,
 } = require("../../db/navalclash")
 const { logger } = require("../../utils/logger")
 
@@ -48,11 +48,15 @@ async function generateUniquePin(conn, name) {
  * Format matches the client's PlayerInfo serialization.
  *
  * @param {Object} user - User object from database
+ * @param {{we: number[], wu: number[]}} weapons - Weapon inventory arrays
  * @returns {Object} Serialized user data for client
  */
-function serializeUserForExport(user) {
+function serializeUserForExport(user, weapons) {
     return {
         nam: user.name,
+        dev: "",
+        id: user.uuid || "",
+        ut: 2,
         i: user.id,
         pin: user.pin,
         rk: user.rank || 0,
@@ -62,7 +66,7 @@ function serializeUserForExport(user) {
         fc: user.face || 0,
         an: user.coins || 0,
         l: user.lang || "en",
-        tz: user.tz || 0,
+        tz: user.timezone || 0,
         ga: [
             user.games_android || 0,
             user.games_bluetooth || 0,
@@ -75,12 +79,120 @@ function serializeUserForExport(user) {
             user.wins_web || 0,
             user.wins_passplay || 0,
         ],
+        we: weapons.we,
+        wu: weapons.wu,
+    }
+}
+
+/**
+ * Merges client profile updates into a user object in-place.
+ * Avoids a re-SELECT after UPDATE by applying known changes locally.
+ *
+ * @param {Object} user - User object from database
+ * @param {Object} clientUser - Client's PlayerInfo object
+ */
+function mergeProfileUpdates(user, clientUser) {
+    if (clientUser.fc != null) user.face = clientUser.fc
+    if (clientUser.l != null) user.lang = clientUser.l
+    if (clientUser.tz != null) user.timezone = clientUser.tz
+    if (clientUser.rk != null) user.rank = clientUser.rk
+    if (clientUser.st != null) user.stars = clientUser.st
+
+    if (Array.isArray(clientUser.ga) && Array.isArray(clientUser.wa)) {
+        user.games_android = clientUser.ga[0] || 0
+        user.games_bluetooth = clientUser.ga[1] || 0
+        user.games_passplay = clientUser.ga[3] || 0
+        user.wins_android = clientUser.wa[0] || 0
+        user.wins_bluetooth = clientUser.wa[1] || 0
+        user.wins_passplay = clientUser.wa[3] || 0
+        user.games =
+            user.games_android +
+            user.games_bluetooth +
+            (user.games_web || 0) +
+            user.games_passplay
+        user.gameswon =
+            user.wins_android +
+            user.wins_bluetooth +
+            (user.wins_web || 0) +
+            user.wins_passplay
+    }
+}
+
+/**
+ * Creates a new user for export with PIN, inside a transaction.
+ *
+ * @param {Object} clientUser - Client's PlayerInfo object
+ * @param {number} version - Client version
+ * @returns {Promise<Object>} Created user object
+ */
+async function createExportUser(clientUser, version) {
+    const conn = await pool.getConnection()
+    try {
+        await conn.beginTransaction()
+
+        const pin = await generateUniquePin(conn, clientUser.nam)
+        const [result] = await conn.execute(
+            `INSERT INTO users (name, uuid, pin, face, lang, timezone,
+                \`rank\`, stars, coins, version)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?)`,
+            [
+                clientUser.nam,
+                clientUser.id || "",
+                pin,
+                clientUser.fc || 0,
+                clientUser.l || "en",
+                clientUser.tz || 0,
+                clientUser.rk || 0,
+                clientUser.st || 0,
+                version || 0,
+            ]
+        )
+
+        const [rows] = await conn.execute(
+            "SELECT * FROM users WHERE id = ?",
+            [result.insertId]
+        )
+        await conn.commit()
+        return rows[0]
+    } catch (error) {
+        await conn.rollback()
+        throw error
+    } finally {
+        conn.release()
+    }
+}
+
+/**
+ * Generates and saves a PIN for an existing user, inside a transaction.
+ *
+ * @param {Object} user - User object from database
+ * @returns {Promise<number>} Generated PIN
+ */
+async function generateAndSavePin(user) {
+    const conn = await pool.getConnection()
+    try {
+        await conn.beginTransaction()
+        const pin = await generateUniquePin(conn, user.name)
+        await conn.execute("UPDATE users SET pin = ? WHERE id = ?", [
+            pin,
+            user.id,
+        ])
+        await conn.commit()
+        return pin
+    } catch (error) {
+        await conn.rollback()
+        throw error
+    } finally {
+        conn.release()
     }
 }
 
 /**
  * Export profile endpoint handler.
  * Saves player data to server and returns a PIN for later recovery.
+ *
+ * Fast path (existing user with PIN): 2 DB queries, no transaction.
+ * Slow path (new user or missing PIN): uses transaction for atomicity.
  *
  * @param {Object} req - Express request
  * @param {Object} res - Express response
@@ -101,75 +213,37 @@ async function exportProfile(req, res) {
     ctx.name = clientUser.nam
     ctx.clientUid = clientUser.id
 
-    const conn = await pool.getConnection()
     try {
-        await conn.beginTransaction()
-
-        // Find user by UUID + name (from client's id field which is device UUID)
         let user = await dbFindUserByUuidAndName(clientUser.id, clientUser.nam)
 
         if (!user) {
-            // User not found - try to find by name only and create if needed
+            // New user - needs transaction for PIN + INSERT
             logger.info(ctx, "User not found by UUID, creating new profile")
-
-            const pin = await generateUniquePin(conn, clientUser.nam)
-            const [result] = await conn.execute(
-                `INSERT INTO users (name, uuid, pin, face, lang, tz, coins, version)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-                [
-                    clientUser.nam,
-                    clientUser.id || "",
-                    pin,
-                    clientUser.fc || 0,
-                    clientUser.l || "en",
-                    clientUser.tz || 0,
-                    clientUser.an || 0,
-                    body.v || 0,
-                ]
-            )
-            const userId = result.insertId
-
-            const [rows] = await conn.execute(
-                "SELECT * FROM users WHERE id = ?",
-                [userId]
-            )
-            user = rows[0]
-            ctx.uid = userId
-            logger.info({ ...ctx, pin }, "New user created for export")
+            user = await createExportUser(clientUser, body.v)
+            ctx.uid = user.id
+            logger.info({ ...ctx, pin: user.pin }, "New user created for export")
         } else {
             ctx.uid = user.id
 
-            // Generate PIN if user doesn't have one
+            // Generate PIN if missing (rare - needs transaction)
             if (!user.pin) {
-                const pin = await generateUniquePin(conn, user.name)
-                await conn.execute("UPDATE users SET pin = ? WHERE id = ?", [
-                    pin,
-                    user.id,
-                ])
-                user.pin = pin
-                logger.info({ ...ctx, pin }, "Generated new PIN for existing user")
+                user.pin = await generateAndSavePin(user)
+                logger.info(
+                    { ...ctx, pin: user.pin },
+                    "Generated new PIN for existing user"
+                )
             }
 
-            // Update profile data from client
-            await dbUpdateUserProfile(conn, user.id, clientUser)
-
-            // Update local game stats
-            if (clientUser.ga && clientUser.wa) {
-                await dbUpdateLocalStats(conn, user.id, clientUser)
-            }
-
-            // Refresh user data
-            const [rows] = await conn.execute(
-                "SELECT * FROM users WHERE id = ?",
-                [user.id]
-            )
-            user = rows[0]
+            // Fast path: single UPDATE, no transaction needed
+            await dbUpdateProfileAndStats(pool, user.id, clientUser)
+            mergeProfileUpdates(user, clientUser)
             logger.info(ctx, "Updated existing user profile")
         }
 
-        await conn.commit()
+        // Fetch weapon inventory for response
+        const weapons = await dbGetUserWeaponArrays(user.id)
 
-        // Log the export action
+        // Log export action (fire and forget)
         dbLogProfileAction(
             user.id,
             "export",
@@ -182,14 +256,11 @@ async function exportProfile(req, res) {
             type: "uexpres",
             id: user.id,
             pin: user.pin,
-            u: serializeUserForExport(user),
+            u: serializeUserForExport(user, weapons),
         })
     } catch (error) {
-        await conn.rollback()
         logger.error(ctx, "Export failed:", error.message)
         return res.json({ type: "error", reason: "Server error" })
-    } finally {
-        conn.release()
     }
 }
 
@@ -230,6 +301,9 @@ async function importProfile(req, res) {
             return res.json({ type: "uimpres" })
         }
 
+        // Fetch weapon inventory for response
+        const weapons = await dbGetUserWeaponArrays(user.id)
+
         // Log the import action
         dbLogProfileAction(user.id, "import", `v=${body.v || 0}`)
 
@@ -237,7 +311,7 @@ async function importProfile(req, res) {
 
         return res.json({
             type: "uimpres",
-            u: serializeUserForExport(user),
+            u: serializeUserForExport(user, weapons),
         })
     } catch (error) {
         logger.error(ctx, "Import failed:", error.message)

--- a/services/navalclash/profileService.js
+++ b/services/navalclash/profileService.js
@@ -148,10 +148,9 @@ async function createExportUser(clientUser, version) {
             ]
         )
 
-        const [rows] = await conn.execute(
-            "SELECT * FROM users WHERE id = ?",
-            [result.insertId]
-        )
+        const [rows] = await conn.execute("SELECT * FROM users WHERE id = ?", [
+            result.insertId,
+        ])
         await conn.commit()
         return rows[0]
     } catch (error) {
@@ -221,7 +220,10 @@ async function exportProfile(req, res) {
             logger.info(ctx, "User not found by UUID, creating new profile")
             user = await createExportUser(clientUser, body.v)
             ctx.uid = user.id
-            logger.info({ ...ctx, pin: user.pin }, "New user created for export")
+            logger.info(
+                { ...ctx, pin: user.pin },
+                "New user created for export"
+            )
         } else {
             ctx.uid = user.id
 
@@ -371,7 +373,10 @@ async function syncProfile(req, res) {
                 if (ignoreErrors) {
                     return res.json({ type: "ok" })
                 }
-                return res.json({ type: "error", reason: "Failed to create user" })
+                return res.json({
+                    type: "error",
+                    reason: "Failed to create user",
+                })
             }
 
             ctx.uid = newUserId

--- a/services/navalclash/profileService.test.js
+++ b/services/navalclash/profileService.test.js
@@ -1,0 +1,368 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ */
+
+const { exportProfile, importProfile } = require("./profileService")
+
+// Mock the database module
+jest.mock("../../db/navalclash", () => {
+    const mockPool = {
+        getConnection: jest.fn(),
+        execute: jest.fn(),
+    }
+    return {
+        pool: mockPool,
+        dbFindUserByUuidAndName: jest.fn(),
+        dbFindUserByNameAndPin: jest.fn(),
+        dbUpdateUserProfile: jest.fn(),
+        dbUpdateLocalStats: jest.fn(),
+        dbLogProfileAction: jest.fn(),
+    }
+})
+
+// Mock the logger
+jest.mock("../../utils/logger", () => ({
+    logger: {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+    },
+}))
+
+const {
+    pool,
+    dbFindUserByUuidAndName,
+    dbFindUserByNameAndPin,
+    dbUpdateUserProfile,
+    dbUpdateLocalStats,
+    dbLogProfileAction,
+} = require("../../db/navalclash")
+
+describe("profileService", () => {
+    let mockReq, mockRes, mockConn
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+
+        mockConn = {
+            beginTransaction: jest.fn(),
+            commit: jest.fn(),
+            rollback: jest.fn(),
+            execute: jest.fn(),
+            release: jest.fn(),
+        }
+        pool.getConnection.mockResolvedValue(mockConn)
+
+        mockRes = {
+            json: jest.fn(),
+        }
+    })
+
+    describe("exportProfile", () => {
+        it("should return error for missing user data", async () => {
+            mockReq = { body: {} }
+
+            await exportProfile(mockReq, mockRes)
+
+            expect(mockRes.json).toHaveBeenCalledWith({
+                type: "error",
+                reason: "Invalid request",
+            })
+        })
+
+        it("should return error for missing player name", async () => {
+            mockReq = { body: { u: { id: "uuid123" } } }
+
+            await exportProfile(mockReq, mockRes)
+
+            expect(mockRes.json).toHaveBeenCalledWith({
+                type: "error",
+                reason: "Invalid request",
+            })
+        })
+
+        it("should export existing user with PIN", async () => {
+            const existingUser = {
+                id: 42,
+                name: "TestPlayer",
+                pin: 1234,
+                rank: 5,
+                stars: 1000,
+                games: 50,
+                gameswon: 30,
+                face: 2,
+                coins: 500,
+                lang: "en",
+                tz: -300,
+                games_android: 10,
+                games_bluetooth: 5,
+                games_web: 30,
+                games_passplay: 5,
+                wins_android: 6,
+                wins_bluetooth: 3,
+                wins_web: 18,
+                wins_passplay: 3,
+            }
+
+            mockReq = {
+                body: {
+                    u: {
+                        nam: "TestPlayer",
+                        id: "uuid123",
+                        fc: 2,
+                        ga: [10, 5, 30, 5],
+                        wa: [6, 3, 18, 3],
+                    },
+                    v: 25,
+                },
+            }
+
+            dbFindUserByUuidAndName.mockResolvedValue(existingUser)
+            dbUpdateUserProfile.mockResolvedValue(true)
+            dbUpdateLocalStats.mockResolvedValue(true)
+            mockConn.execute.mockResolvedValue([[existingUser]])
+
+            await exportProfile(mockReq, mockRes)
+
+            expect(mockConn.beginTransaction).toHaveBeenCalled()
+            expect(mockConn.commit).toHaveBeenCalled()
+            expect(mockRes.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "uexpres",
+                    id: 42,
+                    pin: 1234,
+                    u: expect.objectContaining({
+                        nam: "TestPlayer",
+                        i: 42,
+                        pin: 1234,
+                    }),
+                })
+            )
+        })
+
+        it("should create new user when not found", async () => {
+            const newUser = {
+                id: 99,
+                name: "NewPlayer",
+                pin: 5678,
+                rank: 0,
+                stars: 0,
+                games: 0,
+                gameswon: 0,
+                face: 1,
+                coins: 100,
+                lang: "en",
+                tz: 0,
+            }
+
+            mockReq = {
+                body: {
+                    u: {
+                        nam: "NewPlayer",
+                        id: "newuuid",
+                        fc: 1,
+                        an: 100,
+                    },
+                    v: 25,
+                },
+            }
+
+            dbFindUserByUuidAndName.mockResolvedValue(null)
+            mockConn.execute
+                .mockResolvedValueOnce([[]])  // PIN uniqueness check
+                .mockResolvedValueOnce([{ insertId: 99 }])  // INSERT
+                .mockResolvedValueOnce([[newUser]])  // SELECT after insert
+
+            await exportProfile(mockReq, mockRes)
+
+            expect(mockConn.commit).toHaveBeenCalled()
+            expect(mockRes.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "uexpres",
+                    id: 99,
+                })
+            )
+        })
+
+        it("should generate PIN for existing user without one", async () => {
+            const userWithoutPin = {
+                id: 55,
+                name: "NoPinPlayer",
+                pin: null,
+                rank: 1,
+                stars: 100,
+            }
+            const userWithPin = { ...userWithoutPin, pin: 9999 }
+
+            mockReq = {
+                body: {
+                    u: {
+                        nam: "NoPinPlayer",
+                        id: "uuid555",
+                    },
+                    v: 25,
+                },
+            }
+
+            dbFindUserByUuidAndName.mockResolvedValue(userWithoutPin)
+            dbUpdateUserProfile.mockResolvedValue(true)
+            mockConn.execute
+                .mockResolvedValueOnce([[]])  // PIN uniqueness check
+                .mockResolvedValueOnce([{}])  // UPDATE PIN
+                .mockResolvedValueOnce([[userWithPin]])  // SELECT after update
+
+            await exportProfile(mockReq, mockRes)
+
+            expect(mockRes.json).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "uexpres",
+                    pin: expect.any(Number),
+                })
+            )
+        })
+
+        it("should rollback on error", async () => {
+            mockReq = {
+                body: {
+                    u: {
+                        nam: "ErrorPlayer",
+                        id: "uuid-error",
+                    },
+                },
+            }
+
+            dbFindUserByUuidAndName.mockRejectedValue(new Error("DB error"))
+
+            await exportProfile(mockReq, mockRes)
+
+            expect(mockConn.rollback).toHaveBeenCalled()
+            expect(mockRes.json).toHaveBeenCalledWith({
+                type: "error",
+                reason: "Server error",
+            })
+        })
+    })
+
+    describe("importProfile", () => {
+        it("should return empty response for missing name", async () => {
+            mockReq = { body: { pin: 1234 } }
+
+            await importProfile(mockReq, mockRes)
+
+            expect(mockRes.json).toHaveBeenCalledWith({ type: "uimpres" })
+        })
+
+        it("should return empty response for missing PIN", async () => {
+            mockReq = { body: { name: "TestPlayer" } }
+
+            await importProfile(mockReq, mockRes)
+
+            expect(mockRes.json).toHaveBeenCalledWith({ type: "uimpres" })
+        })
+
+        it("should return empty response for invalid PIN", async () => {
+            mockReq = { body: { name: "TestPlayer", pin: "notanumber" } }
+
+            await importProfile(mockReq, mockRes)
+
+            expect(mockRes.json).toHaveBeenCalledWith({ type: "uimpres" })
+        })
+
+        it("should return user data for valid name + PIN", async () => {
+            const user = {
+                id: 42,
+                name: "TestPlayer",
+                pin: 1234,
+                rank: 5,
+                stars: 1000,
+                games: 50,
+                gameswon: 30,
+                face: 2,
+                coins: 500,
+                lang: "en",
+                tz: -300,
+                isbanned: 0,
+                games_android: 10,
+                games_bluetooth: 5,
+                games_web: 30,
+                games_passplay: 5,
+                wins_android: 6,
+                wins_bluetooth: 3,
+                wins_web: 18,
+                wins_passplay: 3,
+            }
+
+            mockReq = { body: { name: "TestPlayer", pin: "1234", v: 25 } }
+            dbFindUserByNameAndPin.mockResolvedValue(user)
+
+            await importProfile(mockReq, mockRes)
+
+            expect(dbFindUserByNameAndPin).toHaveBeenCalledWith("TestPlayer", 1234)
+            expect(mockRes.json).toHaveBeenCalledWith({
+                type: "uimpres",
+                u: expect.objectContaining({
+                    nam: "TestPlayer",
+                    i: 42,
+                    pin: 1234,
+                    rk: 5,
+                    st: 1000,
+                    pld: 50,
+                    won: 30,
+                }),
+            })
+        })
+
+        it("should return empty response when user not found", async () => {
+            mockReq = { body: { name: "UnknownPlayer", pin: "9999" } }
+            dbFindUserByNameAndPin.mockResolvedValue(null)
+
+            await importProfile(mockReq, mockRes)
+
+            expect(mockRes.json).toHaveBeenCalledWith({ type: "uimpres" })
+        })
+
+        it("should return empty response for banned user", async () => {
+            const bannedUser = {
+                id: 42,
+                name: "BannedPlayer",
+                pin: 1234,
+                isbanned: 1,
+            }
+
+            mockReq = { body: { name: "BannedPlayer", pin: "1234" } }
+            dbFindUserByNameAndPin.mockResolvedValue(bannedUser)
+
+            await importProfile(mockReq, mockRes)
+
+            expect(mockRes.json).toHaveBeenCalledWith({ type: "uimpres" })
+        })
+
+        it("should return empty response on database error", async () => {
+            mockReq = { body: { name: "TestPlayer", pin: "1234" } }
+            dbFindUserByNameAndPin.mockRejectedValue(new Error("DB error"))
+
+            await importProfile(mockReq, mockRes)
+
+            expect(mockRes.json).toHaveBeenCalledWith({ type: "uimpres" })
+        })
+
+        it("should log import action on success", async () => {
+            const user = {
+                id: 42,
+                name: "TestPlayer",
+                pin: 1234,
+                isbanned: 0,
+            }
+
+            mockReq = { body: { name: "TestPlayer", pin: "1234", v: 30 } }
+            dbFindUserByNameAndPin.mockResolvedValue(user)
+
+            await importProfile(mockReq, mockRes)
+
+            expect(dbLogProfileAction).toHaveBeenCalledWith(42, "import", "v=30")
+        })
+    })
+})

--- a/services/navalclash/profileService.test.js
+++ b/services/navalclash/profileService.test.js
@@ -18,10 +18,10 @@ jest.mock("../../db/navalclash", () => {
         dbFindUserByUuid: jest.fn(),
         dbFindUserByNameAndPin: jest.fn(),
         dbCreateUser: jest.fn(),
-        dbUpdateUserProfile: jest.fn(),
         dbSyncUserProfile: jest.fn(),
-        dbUpdateLocalStats: jest.fn(),
+        dbUpdateProfileAndStats: jest.fn(),
         dbLogProfileAction: jest.fn(),
+        dbGetUserWeaponArrays: jest.fn(),
     }
 })
 
@@ -41,10 +41,10 @@ const {
     dbFindUserByUuid,
     dbFindUserByNameAndPin,
     dbCreateUser,
-    dbUpdateUserProfile,
     dbSyncUserProfile,
-    dbUpdateLocalStats,
+    dbUpdateProfileAndStats,
     dbLogProfileAction,
+    dbGetUserWeaponArrays,
 } = require("../../db/navalclash")
 
 describe("profileService", () => {
@@ -65,6 +65,11 @@ describe("profileService", () => {
         mockRes = {
             json: jest.fn(),
         }
+
+        dbGetUserWeaponArrays.mockResolvedValue({
+            we: [0, 0, 0, 0, 0, 0],
+            wu: [0, 0, 0, 0, 0, 0],
+        })
     })
 
     describe("exportProfile", () => {
@@ -94,6 +99,7 @@ describe("profileService", () => {
             const existingUser = {
                 id: 42,
                 name: "TestPlayer",
+                uuid: "uuid123",
                 pin: 1234,
                 rank: 5,
                 stars: 1000,
@@ -102,7 +108,7 @@ describe("profileService", () => {
                 face: 2,
                 coins: 500,
                 lang: "en",
-                tz: -300,
+                timezone: -300,
                 games_android: 10,
                 games_bluetooth: 5,
                 games_web: 30,
@@ -127,14 +133,17 @@ describe("profileService", () => {
             }
 
             dbFindUserByUuidAndName.mockResolvedValue(existingUser)
-            dbUpdateUserProfile.mockResolvedValue(true)
-            dbUpdateLocalStats.mockResolvedValue(true)
-            mockConn.execute.mockResolvedValue([[existingUser]])
+            dbUpdateProfileAndStats.mockResolvedValue(true)
 
             await exportProfile(mockReq, mockRes)
 
-            expect(mockConn.beginTransaction).toHaveBeenCalled()
-            expect(mockConn.commit).toHaveBeenCalled()
+            // Fast path: no transaction needed
+            expect(mockConn.beginTransaction).not.toHaveBeenCalled()
+            expect(dbUpdateProfileAndStats).toHaveBeenCalledWith(
+                pool,
+                42,
+                mockReq.body.u
+            )
             expect(mockRes.json).toHaveBeenCalledWith(
                 expect.objectContaining({
                     type: "uexpres",
@@ -161,7 +170,7 @@ describe("profileService", () => {
                 face: 1,
                 coins: 100,
                 lang: "en",
-                tz: 0,
+                timezone: 0,
             }
 
             mockReq = {
@@ -201,7 +210,6 @@ describe("profileService", () => {
                 rank: 1,
                 stars: 100,
             }
-            const userWithPin = { ...userWithoutPin, pin: 9999 }
 
             mockReq = {
                 body: {
@@ -214,14 +222,16 @@ describe("profileService", () => {
             }
 
             dbFindUserByUuidAndName.mockResolvedValue(userWithoutPin)
-            dbUpdateUserProfile.mockResolvedValue(true)
+            dbUpdateProfileAndStats.mockResolvedValue(true)
             mockConn.execute
                 .mockResolvedValueOnce([[]])  // PIN uniqueness check
                 .mockResolvedValueOnce([{}])  // UPDATE PIN
-                .mockResolvedValueOnce([[userWithPin]])  // SELECT after update
 
             await exportProfile(mockReq, mockRes)
 
+            // Transaction used only for PIN generation
+            expect(mockConn.beginTransaction).toHaveBeenCalled()
+            expect(mockConn.commit).toHaveBeenCalled()
             expect(mockRes.json).toHaveBeenCalledWith(
                 expect.objectContaining({
                     type: "uexpres",
@@ -230,7 +240,7 @@ describe("profileService", () => {
             )
         })
 
-        it("should rollback on error", async () => {
+        it("should return error on DB failure", async () => {
             mockReq = {
                 body: {
                     u: {
@@ -241,6 +251,27 @@ describe("profileService", () => {
             }
 
             dbFindUserByUuidAndName.mockRejectedValue(new Error("DB error"))
+
+            await exportProfile(mockReq, mockRes)
+
+            expect(mockRes.json).toHaveBeenCalledWith({
+                type: "error",
+                reason: "Server error",
+            })
+        })
+
+        it("should rollback on error during new user creation", async () => {
+            mockReq = {
+                body: {
+                    u: {
+                        nam: "ErrorPlayer",
+                        id: "uuid-error",
+                    },
+                },
+            }
+
+            dbFindUserByUuidAndName.mockResolvedValue(null)
+            mockConn.execute.mockRejectedValue(new Error("INSERT failed"))
 
             await exportProfile(mockReq, mockRes)
 
@@ -281,6 +312,7 @@ describe("profileService", () => {
             const user = {
                 id: 42,
                 name: "TestPlayer",
+                uuid: "uuid-test-42",
                 pin: 1234,
                 rank: 5,
                 stars: 1000,
@@ -289,7 +321,7 @@ describe("profileService", () => {
                 face: 2,
                 coins: 500,
                 lang: "en",
-                tz: -300,
+                timezone: -300,
                 isbanned: 0,
                 games_android: 10,
                 games_bluetooth: 5,
@@ -311,6 +343,9 @@ describe("profileService", () => {
                 type: "uimpres",
                 u: expect.objectContaining({
                     nam: "TestPlayer",
+                    dev: "",
+                    id: "uuid-test-42",
+                    ut: 2,
                     i: 42,
                     pin: 1234,
                     rk: 5,

--- a/services/navalclash/profileService.test.js
+++ b/services/navalclash/profileService.test.js
@@ -4,7 +4,11 @@
  * All rights reserved.
  */
 
-const { exportProfile, importProfile, syncProfile } = require("./profileService")
+const {
+    exportProfile,
+    importProfile,
+    syncProfile,
+} = require("./profileService")
 
 // Mock the database module
 jest.mock("../../db/navalclash", () => {
@@ -187,9 +191,9 @@ describe("profileService", () => {
 
             dbFindUserByUuidAndName.mockResolvedValue(null)
             mockConn.execute
-                .mockResolvedValueOnce([[]])  // PIN uniqueness check
-                .mockResolvedValueOnce([{ insertId: 99 }])  // INSERT
-                .mockResolvedValueOnce([[newUser]])  // SELECT after insert
+                .mockResolvedValueOnce([[]]) // PIN uniqueness check
+                .mockResolvedValueOnce([{ insertId: 99 }]) // INSERT
+                .mockResolvedValueOnce([[newUser]]) // SELECT after insert
 
             await exportProfile(mockReq, mockRes)
 
@@ -224,8 +228,8 @@ describe("profileService", () => {
             dbFindUserByUuidAndName.mockResolvedValue(userWithoutPin)
             dbUpdateProfileAndStats.mockResolvedValue(true)
             mockConn.execute
-                .mockResolvedValueOnce([[]])  // PIN uniqueness check
-                .mockResolvedValueOnce([{}])  // UPDATE PIN
+                .mockResolvedValueOnce([[]]) // PIN uniqueness check
+                .mockResolvedValueOnce([{}]) // UPDATE PIN
 
             await exportProfile(mockReq, mockRes)
 
@@ -338,7 +342,10 @@ describe("profileService", () => {
 
             await importProfile(mockReq, mockRes)
 
-            expect(dbFindUserByNameAndPin).toHaveBeenCalledWith("TestPlayer", 1234)
+            expect(dbFindUserByNameAndPin).toHaveBeenCalledWith(
+                "TestPlayer",
+                1234
+            )
             expect(mockRes.json).toHaveBeenCalledWith({
                 type: "uimpres",
                 u: expect.objectContaining({
@@ -403,7 +410,11 @@ describe("profileService", () => {
 
             await importProfile(mockReq, mockRes)
 
-            expect(dbLogProfileAction).toHaveBeenCalledWith(42, "import", "v=30")
+            expect(dbLogProfileAction).toHaveBeenCalledWith(
+                42,
+                "import",
+                "v=30"
+            )
         })
     })
 
@@ -431,8 +442,15 @@ describe("profileService", () => {
 
             await syncProfile(mockReq, mockRes)
 
-            expect(dbFindUserByUuidAndName).toHaveBeenCalledWith("uuid123", "TestPlayer")
-            expect(dbSyncUserProfile).toHaveBeenCalledWith(42, mockReq.body.u, 25)
+            expect(dbFindUserByUuidAndName).toHaveBeenCalledWith(
+                "uuid123",
+                "TestPlayer"
+            )
+            expect(dbSyncUserProfile).toHaveBeenCalledWith(
+                42,
+                mockReq.body.u,
+                25
+            )
             expect(mockRes.json).toHaveBeenCalledWith({ type: "ok" })
         })
 
@@ -451,9 +469,16 @@ describe("profileService", () => {
 
             await syncProfile(mockReq, mockRes)
 
-            expect(dbFindUserByUuidAndName).toHaveBeenCalledWith("uuid123", "TestPlayer")
+            expect(dbFindUserByUuidAndName).toHaveBeenCalledWith(
+                "uuid123",
+                "TestPlayer"
+            )
             expect(dbFindUserByUuid).toHaveBeenCalledWith("uuid123")
-            expect(dbSyncUserProfile).toHaveBeenCalledWith(42, mockReq.body.u, 25)
+            expect(dbSyncUserProfile).toHaveBeenCalledWith(
+                42,
+                mockReq.body.u,
+                25
+            )
             expect(mockRes.json).toHaveBeenCalledWith({ type: "ok" })
         })
 
@@ -478,7 +503,11 @@ describe("profileService", () => {
                 uuid: "new-uuid-123",
                 gameVariant: 1,
             })
-            expect(dbSyncUserProfile).toHaveBeenCalledWith(99, mockReq.body.u, 25)
+            expect(dbSyncUserProfile).toHaveBeenCalledWith(
+                99,
+                mockReq.body.u,
+                25
+            )
             expect(mockRes.json).toHaveBeenCalledWith({ type: "ok" })
         })
 

--- a/services/navalclash/sessionPurge.js
+++ b/services/navalclash/sessionPurge.js
@@ -79,11 +79,17 @@ async function purgeStaleSessions(purgeThresholdSec) {
 
         // Clean up old messages from closed sessions (older than 1 hour)
         await pool.execute(
-            `DELETE sm FROM session_messages sm
-             LEFT JOIN game_sessions gs ON gs.id = (sm.sender_session_id & ~1)
-             WHERE gs.id IS NULL
-                OR (gs.status > 1 AND gs.finished_at < DATE_SUB(NOW(), INTERVAL 1 HOUR))
-             LIMIT 500`
+            `DELETE FROM session_messages
+             WHERE msg_id IN (
+                 SELECT msg_id FROM (
+                     SELECT sm.msg_id
+                     FROM session_messages sm
+                     LEFT JOIN game_sessions gs ON gs.id = (sm.sender_session_id & ~1)
+                     WHERE gs.id IS NULL
+                        OR (gs.status > 1 AND gs.finished_at < DATE_SUB(NOW(), INTERVAL 1 HOUR))
+                     LIMIT 500
+                 ) tmp
+             )`
         )
     } catch (error) {
         console.error("Session purge error:", error.message)

--- a/services/navalclash/sessionPurge.js
+++ b/services/navalclash/sessionPurge.js
@@ -1,0 +1,138 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ *
+ * Background session purge job.
+ * Runs in the cluster master process to clean up stale sessions
+ * where players have stopped polling.
+ */
+
+const { pool } = require("../../db/navalclash/pool")
+const { TIMING } = require("./constants")
+
+const SESSION_STATUS = {
+    FINISHED_TIMED_OUT_WAITING: 5,
+    FINISHED_TIMED_OUT_PLAYING: 6,
+}
+
+/**
+ * Finds and closes stale sessions.
+ * - WAITING sessions where player one is stale (>purgeThreshold) → FINISHED_TIMED_OUT_WAITING
+ * - IN_PROGRESS sessions where both players are stale (>purgeThreshold) → FINISHED_TIMED_OUT_PLAYING
+ *
+ * @param {number} purgeThresholdSec - Seconds of inactivity before purge
+ * @returns {Promise<number>} Number of sessions closed
+ */
+async function purgeStaleSessions(purgeThresholdSec) {
+    let closed = 0
+    try {
+        // Find stale waiting sessions (status=0, player one inactive)
+        const [waitingRows] = await pool.execute(
+            `SELECT id FROM game_sessions
+             WHERE status = 0
+               AND (
+                   last_seen_one IS NULL
+                   OR last_seen_one < DATE_SUB(NOW(3), INTERVAL ? SECOND)
+               )
+             LIMIT 100`,
+            [purgeThresholdSec]
+        )
+
+        for (const row of waitingRows) {
+            const [result] = await pool.execute(
+                `UPDATE game_sessions SET
+                    status = ?,
+                    finished_at = NOW(3)
+                 WHERE id = ? AND status = 0`,
+                [SESSION_STATUS.FINISHED_TIMED_OUT_WAITING, row.id.toString()]
+            )
+            if (result.affectedRows > 0) closed++
+        }
+
+        // Find stale in-progress sessions (status=1, both players inactive)
+        const [playingRows] = await pool.execute(
+            `SELECT id FROM game_sessions
+             WHERE status = 1
+               AND (
+                   last_seen_one IS NULL
+                   OR last_seen_one < DATE_SUB(NOW(3), INTERVAL ? SECOND)
+               )
+               AND (
+                   last_seen_two IS NULL
+                   OR last_seen_two < DATE_SUB(NOW(3), INTERVAL ? SECOND)
+               )
+             LIMIT 100`,
+            [purgeThresholdSec, purgeThresholdSec]
+        )
+
+        for (const row of playingRows) {
+            const [result] = await pool.execute(
+                `UPDATE game_sessions SET
+                    status = ?,
+                    finished_at = NOW(3)
+                 WHERE id = ? AND status = 1`,
+                [SESSION_STATUS.FINISHED_TIMED_OUT_PLAYING, row.id.toString()]
+            )
+            if (result.affectedRows > 0) closed++
+        }
+
+        // Clean up old messages from closed sessions (older than 1 hour)
+        await pool.execute(
+            `DELETE sm FROM session_messages sm
+             LEFT JOIN game_sessions gs ON gs.id = (sm.sender_session_id & ~1)
+             WHERE gs.id IS NULL
+                OR (gs.status > 1 AND gs.finished_at < DATE_SUB(NOW(), INTERVAL 1 HOUR))
+             LIMIT 500`
+        )
+    } catch (error) {
+        console.error("Session purge error:", error.message)
+    }
+
+    return closed
+}
+
+let purgeInterval = null
+
+/**
+ * Starts the background session purge job.
+ * Should be called from the cluster master process.
+ *
+ * @returns {void}
+ */
+function startSessionPurge() {
+    const intervalMs = TIMING.SESSION_PURGE_INTERVAL_MS
+    const thresholdSec = Math.floor(TIMING.SESSION_PURGE_MS / 1000)
+
+    console.log(
+        `Session purge: starting (interval=${intervalMs}ms, threshold=${thresholdSec}s)`
+    )
+
+    purgeInterval = setInterval(async () => {
+        const closed = await purgeStaleSessions(thresholdSec)
+        if (closed > 0) {
+            console.log(`Session purge: closed ${closed} stale session(s)`)
+        }
+    }, intervalMs)
+
+    // Don't block process exit
+    purgeInterval.unref()
+}
+
+/**
+ * Stops the background session purge job.
+ *
+ * @returns {void}
+ */
+function stopSessionPurge() {
+    if (purgeInterval) {
+        clearInterval(purgeInterval)
+        purgeInterval = null
+    }
+}
+
+module.exports = {
+    purgeStaleSessions,
+    startSessionPurge,
+    stopSessionPurge,
+}

--- a/services/navalclash/sessionPurge.test.js
+++ b/services/navalclash/sessionPurge.test.js
@@ -1,0 +1,133 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ */
+
+const mockExecute = jest.fn()
+
+jest.mock("../../db/navalclash/pool", () => ({
+    pool: {
+        execute: mockExecute,
+    },
+}))
+
+const {
+    purgeStaleSessions,
+    startSessionPurge,
+    stopSessionPurge,
+} = require("./sessionPurge")
+
+describe("services/navalclash/sessionPurge", () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    afterEach(() => {
+        stopSessionPurge()
+    })
+
+    describe("purgeStaleSessions", () => {
+        it("should close stale waiting sessions with FINISHED_TIMED_OUT_WAITING", async () => {
+            // Find stale waiting sessions
+            mockExecute
+                .mockResolvedValueOnce([[{ id: "1000" }]]) // stale waiting
+                .mockResolvedValueOnce([{ affectedRows: 1 }]) // close it
+                .mockResolvedValueOnce([[]]) // no stale playing
+                .mockResolvedValueOnce([{ affectedRows: 0 }]) // message cleanup
+
+            const closed = await purgeStaleSessions(120)
+
+            expect(closed).toBe(1)
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("status = 0"),
+                [120]
+            )
+            // Should close with status 5 (FINISHED_TIMED_OUT_WAITING)
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("status = ?"),
+                [5, "1000"]
+            )
+        })
+
+        it("should close stale playing sessions with FINISHED_TIMED_OUT_PLAYING", async () => {
+            // No stale waiting sessions
+            mockExecute
+                .mockResolvedValueOnce([[]]) // no stale waiting
+                .mockResolvedValueOnce([[{ id: "2000" }]]) // stale playing
+                .mockResolvedValueOnce([{ affectedRows: 1 }]) // close it
+                .mockResolvedValueOnce([{ affectedRows: 0 }]) // message cleanup
+
+            const closed = await purgeStaleSessions(120)
+
+            expect(closed).toBe(1)
+            // Should close with status 6 (FINISHED_TIMED_OUT_PLAYING)
+            expect(mockExecute).toHaveBeenCalledWith(
+                expect.stringContaining("status = ?"),
+                [6, "2000"]
+            )
+        })
+
+        it("should handle multiple stale sessions", async () => {
+            mockExecute
+                .mockResolvedValueOnce([
+                    [{ id: "1000" }, { id: "1002" }],
+                ]) // 2 stale waiting
+                .mockResolvedValueOnce([{ affectedRows: 1 }]) // close 1000
+                .mockResolvedValueOnce([{ affectedRows: 1 }]) // close 1002
+                .mockResolvedValueOnce([[{ id: "2000" }]]) // 1 stale playing
+                .mockResolvedValueOnce([{ affectedRows: 1 }]) // close 2000
+                .mockResolvedValueOnce([{ affectedRows: 0 }]) // message cleanup
+
+            const closed = await purgeStaleSessions(120)
+
+            expect(closed).toBe(3)
+        })
+
+        it("should return 0 when no stale sessions", async () => {
+            mockExecute
+                .mockResolvedValueOnce([[]]) // no stale waiting
+                .mockResolvedValueOnce([[]]) // no stale playing
+                .mockResolvedValueOnce([{ affectedRows: 0 }]) // message cleanup
+
+            const closed = await purgeStaleSessions(120)
+
+            expect(closed).toBe(0)
+        })
+
+        it("should not count already-closed sessions", async () => {
+            mockExecute
+                .mockResolvedValueOnce([[{ id: "1000" }]]) // stale waiting
+                .mockResolvedValueOnce([{ affectedRows: 0 }]) // already closed
+                .mockResolvedValueOnce([[]]) // no stale playing
+                .mockResolvedValueOnce([{ affectedRows: 0 }]) // message cleanup
+
+            const closed = await purgeStaleSessions(120)
+
+            expect(closed).toBe(0)
+        })
+
+        it("should handle database errors gracefully", async () => {
+            mockExecute.mockRejectedValueOnce(new Error("DB connection lost"))
+
+            const closed = await purgeStaleSessions(120)
+
+            expect(closed).toBe(0)
+        })
+    })
+
+    describe("startSessionPurge / stopSessionPurge", () => {
+        it("should start without throwing", () => {
+            expect(() => startSessionPurge()).not.toThrow()
+        })
+
+        it("should stop without throwing", () => {
+            startSessionPurge()
+            expect(() => stopSessionPurge()).not.toThrow()
+        })
+
+        it("should be safe to stop when not started", () => {
+            expect(() => stopSessionPurge()).not.toThrow()
+        })
+    })
+})

--- a/services/navalclash/setupService.js
+++ b/services/navalclash/setupService.js
@@ -1,0 +1,134 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ */
+
+const { pool } = require("../../db/navalclash")
+const { logger } = require("../../utils/logger")
+const { TIMING } = require("./constants")
+
+// In-memory cache for gamesetup values
+const configCache = new Map()
+
+/**
+ * Cache entry structure.
+ * @typedef {Object} CacheEntry
+ * @property {number|string|null} value - Cached value
+ * @property {number} expiresAt - Expiration timestamp in ms
+ */
+
+/**
+ * Gets a config value from cache or database.
+ * Values are cached for 1 hour to minimize database queries.
+ *
+ * @param {string} name - Config name (e.g., 'min_version', 'maintenance_mode')
+ * @returns {Promise<Object|null>} Config object with int_value, str_value, or null if not found
+ */
+async function getConfig(name) {
+    const now = Date.now()
+    const cached = configCache.get(name)
+
+    // Return cached value if still valid
+    if (cached && cached.expiresAt > now) {
+        logger.debug({ config: name, cached: true }, "Config cache hit")
+        return cached.value
+    }
+
+    // Fetch from database
+    try {
+        const [rows] = await pool.execute(
+            "SELECT * FROM gamesetup WHERE name = ?",
+            [name]
+        )
+
+        const value = rows.length > 0 ? rows[0] : null
+
+        // Cache the result (even null values to prevent repeated queries)
+        configCache.set(name, {
+            value,
+            expiresAt: now + TIMING.CACHE_TTL_MS,
+        })
+
+        logger.debug(
+            { config: name, cached: false, found: !!value },
+            "Config loaded from database"
+        )
+        return value
+    } catch (error) {
+        logger.error({ config: name }, "Failed to load config:", error.message)
+        return null
+    }
+}
+
+/**
+ * Gets the minimum allowed client version.
+ * Returns 0 if not configured (allows all versions).
+ *
+ * @returns {Promise<number>} Minimum version number
+ */
+async function getMinVersion() {
+    const config = await getConfig("min_version")
+    return config?.int_value || 0
+}
+
+/**
+ * Checks if the server is in maintenance mode.
+ *
+ * @returns {Promise<boolean>} True if maintenance mode is enabled
+ */
+async function isMaintenanceMode() {
+    const config = await getConfig("maintenance_mode")
+    return !!(config?.int_value)
+}
+
+/**
+ * Invalidates a specific config cache entry.
+ * Useful when config is updated via admin interface.
+ *
+ * @param {string} name - Config name to invalidate
+ */
+function invalidateConfig(name) {
+    configCache.delete(name)
+    logger.info({ config: name }, "Config cache invalidated")
+}
+
+/**
+ * Invalidates all cached config entries.
+ */
+function invalidateAllConfigs() {
+    configCache.clear()
+    logger.info({}, "All config caches invalidated")
+}
+
+/**
+ * Gets cache statistics for monitoring.
+ *
+ * @returns {Object} Cache stats including size and entries
+ */
+function getCacheStats() {
+    const now = Date.now()
+    const entries = []
+
+    for (const [name, entry] of configCache) {
+        entries.push({
+            name,
+            expiresIn: Math.max(0, Math.floor((entry.expiresAt - now) / 1000)),
+            hasValue: entry.value !== null,
+        })
+    }
+
+    return {
+        size: configCache.size,
+        entries,
+    }
+}
+
+module.exports = {
+    getConfig,
+    getMinVersion,
+    isMaintenanceMode,
+    invalidateConfig,
+    invalidateAllConfigs,
+    getCacheStats,
+}

--- a/services/navalclash/setupService.js
+++ b/services/navalclash/setupService.js
@@ -79,7 +79,7 @@ async function getMinVersion() {
  */
 async function isMaintenanceMode() {
     const config = await getConfig("maintenance_mode")
-    return !!(config?.int_value)
+    return !!config?.int_value
 }
 
 /**

--- a/services/navalclash/setupService.test.js
+++ b/services/navalclash/setupService.test.js
@@ -1,0 +1,221 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ */
+
+const mockExecute = jest.fn()
+
+jest.mock("../../db/navalclash", () => ({
+    pool: {
+        execute: mockExecute,
+    },
+}))
+
+// Must require after mocking
+const {
+    getConfig,
+    getMinVersion,
+    isMaintenanceMode,
+    invalidateConfig,
+    invalidateAllConfigs,
+    getCacheStats,
+} = require("./setupService")
+
+const { TIMING } = require("./constants")
+
+describe("services/navalclash/setupService", () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        // Clear cache between tests
+        invalidateAllConfigs()
+    })
+
+    describe("getConfig", () => {
+        it("should fetch config from database on first call", async () => {
+            mockExecute.mockResolvedValueOnce([
+                [{ name: "test_config", int_value: 42, str_value: null }],
+            ])
+
+            const result = await getConfig("test_config")
+
+            expect(mockExecute).toHaveBeenCalledWith(
+                "SELECT * FROM gamesetup WHERE name = ?",
+                ["test_config"]
+            )
+            expect(result).toEqual({
+                name: "test_config",
+                int_value: 42,
+                str_value: null,
+            })
+        })
+
+        it("should return cached value on subsequent calls", async () => {
+            mockExecute.mockResolvedValueOnce([
+                [{ name: "cached_config", int_value: 100 }],
+            ])
+
+            // First call - fetches from DB
+            await getConfig("cached_config")
+            expect(mockExecute).toHaveBeenCalledTimes(1)
+
+            // Second call - should use cache
+            const result = await getConfig("cached_config")
+            expect(mockExecute).toHaveBeenCalledTimes(1) // Still 1
+            expect(result.int_value).toBe(100)
+        })
+
+        it("should return null for non-existent config", async () => {
+            mockExecute.mockResolvedValueOnce([[]])
+
+            const result = await getConfig("nonexistent")
+
+            expect(result).toBeNull()
+        })
+
+        it("should cache null values to prevent repeated queries", async () => {
+            mockExecute.mockResolvedValueOnce([[]])
+
+            await getConfig("missing_config")
+            await getConfig("missing_config")
+
+            // Should only query once, even for null results
+            expect(mockExecute).toHaveBeenCalledTimes(1)
+        })
+
+        it("should handle database errors gracefully", async () => {
+            mockExecute.mockRejectedValueOnce(new Error("DB Error"))
+
+            const result = await getConfig("error_config")
+
+            expect(result).toBeNull()
+        })
+    })
+
+    describe("getMinVersion", () => {
+        it("should return min_version int_value", async () => {
+            mockExecute.mockResolvedValueOnce([
+                [{ name: "min_version", int_value: 25 }],
+            ])
+
+            const result = await getMinVersion()
+
+            expect(result).toBe(25)
+        })
+
+        it("should return 0 if min_version not configured", async () => {
+            mockExecute.mockResolvedValueOnce([[]])
+
+            const result = await getMinVersion()
+
+            expect(result).toBe(0)
+        })
+
+        it("should return 0 if int_value is null", async () => {
+            mockExecute.mockResolvedValueOnce([
+                [{ name: "min_version", int_value: null }],
+            ])
+
+            const result = await getMinVersion()
+
+            expect(result).toBe(0)
+        })
+    })
+
+    describe("isMaintenanceMode", () => {
+        it("should return true when maintenance_mode is 1", async () => {
+            mockExecute.mockResolvedValueOnce([
+                [{ name: "maintenance_mode", int_value: 1 }],
+            ])
+
+            const result = await isMaintenanceMode()
+
+            expect(result).toBe(true)
+        })
+
+        it("should return false when maintenance_mode is 0", async () => {
+            mockExecute.mockResolvedValueOnce([
+                [{ name: "maintenance_mode", int_value: 0 }],
+            ])
+
+            const result = await isMaintenanceMode()
+
+            expect(result).toBe(false)
+        })
+
+        it("should return false when maintenance_mode not configured", async () => {
+            mockExecute.mockResolvedValueOnce([[]])
+
+            const result = await isMaintenanceMode()
+
+            expect(result).toBe(false)
+        })
+    })
+
+    describe("invalidateConfig", () => {
+        it("should clear specific config from cache", async () => {
+            mockExecute.mockResolvedValue([
+                [{ name: "test", int_value: 1 }],
+            ])
+
+            // Populate cache
+            await getConfig("test")
+            expect(mockExecute).toHaveBeenCalledTimes(1)
+
+            // Invalidate and fetch again
+            invalidateConfig("test")
+            await getConfig("test")
+
+            // Should query DB again
+            expect(mockExecute).toHaveBeenCalledTimes(2)
+        })
+    })
+
+    describe("invalidateAllConfigs", () => {
+        it("should clear all configs from cache", async () => {
+            mockExecute.mockResolvedValue([[{ int_value: 1 }]])
+
+            // Populate cache with multiple configs
+            await getConfig("config1")
+            await getConfig("config2")
+            expect(mockExecute).toHaveBeenCalledTimes(2)
+
+            // Invalidate all
+            invalidateAllConfigs()
+
+            // Fetch again - should query DB
+            await getConfig("config1")
+            await getConfig("config2")
+            expect(mockExecute).toHaveBeenCalledTimes(4)
+        })
+    })
+
+    describe("getCacheStats", () => {
+        it("should return cache statistics", async () => {
+            mockExecute.mockResolvedValue([[{ int_value: 1 }]])
+
+            await getConfig("stat_test")
+
+            const stats = getCacheStats()
+
+            expect(stats.size).toBe(1)
+            expect(stats.entries).toHaveLength(1)
+            expect(stats.entries[0].name).toBe("stat_test")
+            expect(stats.entries[0].hasValue).toBe(true)
+            expect(stats.entries[0].expiresIn).toBeGreaterThan(0)
+        })
+
+        it("should return empty stats when cache is empty", () => {
+            const stats = getCacheStats()
+
+            expect(stats.size).toBe(0)
+            expect(stats.entries).toHaveLength(0)
+        })
+    })
+
+    describe("TIMING.CACHE_TTL_MS", () => {
+        it("should be 1 hour in milliseconds", () => {
+            expect(TIMING.CACHE_TTL_MS).toBe(60 * 60 * 1000)
+        })
+    })
+})

--- a/services/navalclash/setupService.test.js
+++ b/services/navalclash/setupService.test.js
@@ -154,9 +154,7 @@ describe("services/navalclash/setupService", () => {
 
     describe("invalidateConfig", () => {
         it("should clear specific config from cache", async () => {
-            mockExecute.mockResolvedValue([
-                [{ name: "test", int_value: 1 }],
-            ])
+            mockExecute.mockResolvedValue([[{ name: "test", int_value: 1 }]])
 
             // Populate cache
             await getConfig("test")

--- a/services/navalclash/shopService.js
+++ b/services/navalclash/shopService.js
@@ -7,16 +7,7 @@
 const { pool } = require("../../db/navalclash")
 const { logger } = require("../../utils/logger")
 const { val2mess } = require("./gameService")
-
-// Error codes for ibya response
-const BUY_ERROR = {
-    SUCCESS: 0,
-    WRONG_PRICE: 3,
-    DENIED: -1,
-}
-
-// Weapon index to name mapping
-const WEAPON_NAMES = ["mine", "dutch", "radar", "shuffle", "stealth", "cshield"]
+const { BUY_ERROR, WEAPON_NAMES } = require("./constants")
 
 /**
  * Serializes an inventory item for API response.

--- a/services/navalclash/shopService.js
+++ b/services/navalclash/shopService.js
@@ -6,6 +6,17 @@
 
 const { pool } = require("../../db/navalclash")
 const { logger } = require("../../utils/logger")
+const { val2mess } = require("./gameService")
+
+// Error codes for ibya response
+const BUY_ERROR = {
+    SUCCESS: 0,
+    WRONG_PRICE: 3,
+    DENIED: -1,
+}
+
+// Weapon index to name mapping
+const WEAPON_NAMES = ["mine", "dutch", "radar", "shuffle", "stealth", "cshield"]
 
 /**
  * Serializes an inventory item for API response.
@@ -169,11 +180,242 @@ async function getCoins(userId) {
     }
 }
 
+/**
+ * Builds user object for ibya response with weapon quantities.
+ * Coins are ENCODED with val2mess().
+ *
+ * @param {Object} user - User data from database
+ * @param {Array} weapons - Weapon quantities array [mine, dutch, radar, shuffle, stealth, cshield]
+ * @returns {Object} User object for response
+ */
+function buildUserResponse(user, weapons) {
+    return {
+        nam: user.name,
+        dev: "",
+        id: user.uuid,
+        ut: 2,
+        rk: user.rank || 0,
+        st: user.stars || 0,
+        pld: user.games || 0,
+        won: user.gameswon || 0,
+        an: val2mess(user.coins || 0), // Coins ENCODED
+        // Weapon quantities array (we[] in client) - indices 0-5
+        we: weapons,
+    }
+}
+
+/**
+ * Internal buy (iby) endpoint - purchase weapons with in-game coins.
+ *
+ * Request format:
+ * {
+ *   type: "iby",
+ *   u: { user object },
+ *   lg: "en",
+ *   tkn: 123456,
+ *   its: [{ sku: "0", q: 5, p: 100 }, ...]
+ * }
+ *
+ * Response format (ibya):
+ * {
+ *   type: "ibya",
+ *   rc: 0,  // 0=success, 3=wrong price/no coins, -1=denied
+ *   u: { updated user with encoded coins and weapon quantities }
+ * }
+ *
+ * @param {Object} req - Express request
+ * @param {Object} res - Express response
+ * @returns {Promise<Object>} JSON response
+ */
+async function internalBuy(req, res) {
+    const { u, lg, tkn, its } = req.body
+    const ctx = { reqId: req.requestId }
+
+    logger.debug(ctx, "Internal buy request", { lg, hasUser: !!u, itemCount: its?.length })
+
+    // Validate request
+    if (!u || !u.id) {
+        logger.warn(ctx, "Internal buy missing user")
+        return res.json({
+            type: "ibya",
+            rc: BUY_ERROR.DENIED,
+            msg: { text: "Missing user" },
+        })
+    }
+
+    if (!its || !Array.isArray(its) || its.length === 0) {
+        logger.warn(ctx, "Internal buy missing items")
+        return res.json({
+            type: "ibya",
+            rc: BUY_ERROR.DENIED,
+            msg: { text: "Missing items" },
+        })
+    }
+
+    ctx.uuid = u.id
+    ctx.userName = u.nam
+
+    const conn = await pool.getConnection()
+    try {
+        await conn.beginTransaction()
+
+        // Find user by UUID
+        const [users] = await conn.execute(
+            `SELECT id, name, uuid, \`rank\`, stars, games, gameswon, coins
+             FROM users WHERE uuid = ? FOR UPDATE`,
+            [u.id]
+        )
+
+        if (users.length === 0) {
+            await conn.rollback()
+            logger.warn(ctx, "Internal buy user not found")
+            return res.json({
+                type: "ibya",
+                rc: BUY_ERROR.DENIED,
+                msg: { text: "User not found" },
+            })
+        }
+
+        const user = users[0]
+        ctx.uid = user.id
+
+        // Get server's price list
+        const [shopItems] = await conn.execute(
+            "SELECT weapon_index, price FROM shop_items WHERE is_active = 1"
+        )
+        const priceMap = new Map(shopItems.map((item) => [String(item.weapon_index), item.price]))
+
+        // Validate prices and calculate total cost
+        let totalCost = 0
+        const validatedItems = []
+
+        for (const item of its) {
+            const { sku, q, p } = item
+            const serverPrice = priceMap.get(sku)
+
+            if (serverPrice === undefined) {
+                await conn.rollback()
+                logger.warn({ ...ctx, sku }, "Internal buy invalid SKU")
+                return res.json({
+                    type: "ibya",
+                    rc: BUY_ERROR.WRONG_PRICE,
+                    msg: { text: "Invalid item" },
+                })
+            }
+
+            // Validate price matches server
+            if (p !== serverPrice) {
+                await conn.rollback()
+                logger.warn({ ...ctx, sku, clientPrice: p, serverPrice }, "Internal buy price mismatch")
+                return res.json({
+                    type: "ibya",
+                    rc: BUY_ERROR.WRONG_PRICE,
+                    msg: { text: "Price mismatch" },
+                })
+            }
+
+            // q > 0 = buy, q < 0 = sell
+            const cost = q * serverPrice
+            totalCost += cost
+            validatedItems.push({ sku, qty: q, price: serverPrice })
+        }
+
+        // Check if user has enough coins
+        if (totalCost > user.coins) {
+            await conn.rollback()
+            logger.warn({ ...ctx, totalCost, userCoins: user.coins }, "Internal buy insufficient coins")
+            return res.json({
+                type: "ibya",
+                rc: BUY_ERROR.WRONG_PRICE,
+                msg: { text: "Insufficient coins" },
+            })
+        }
+
+        // Deduct coins
+        const newCoins = user.coins - totalCost
+        await conn.execute("UPDATE users SET coins = ? WHERE id = ?", [newCoins, user.id])
+
+        // Update inventory for each item
+        for (const item of validatedItems) {
+            if (item.qty > 0) {
+                // Buying - add to inventory (upsert)
+                await conn.execute(
+                    `INSERT INTO user_inventory (user_id, item_type, item_id, quantity)
+                     VALUES (?, 'weapon', ?, ?)
+                     ON DUPLICATE KEY UPDATE quantity = quantity + ?`,
+                    [user.id, item.sku, item.qty, item.qty]
+                )
+            } else if (item.qty < 0) {
+                // Selling - subtract from inventory
+                await conn.execute(
+                    `UPDATE user_inventory
+                     SET quantity = GREATEST(0, quantity + ?)
+                     WHERE user_id = ? AND item_type = 'weapon' AND item_id = ?`,
+                    [item.qty, user.id, item.sku]
+                )
+            }
+        }
+
+        // Get updated weapon quantities
+        const [inventory] = await conn.execute(
+            `SELECT item_id, quantity FROM user_inventory
+             WHERE user_id = ? AND item_type = 'weapon'`,
+            [user.id]
+        )
+
+        // Build weapons array (indices 0-5)
+        const weapons = [0, 0, 0, 0, 0, 0]
+        for (const inv of inventory) {
+            const idx = parseInt(inv.item_id, 10)
+            if (idx >= 0 && idx < 6) {
+                weapons[idx] = inv.quantity
+            }
+        }
+
+        await conn.commit()
+
+        // Update user object with new coins for response
+        user.coins = newCoins
+
+        // Log each item purchased with name, qty, price
+        const itemDetails = validatedItems.map((item) => {
+            const weaponName = WEAPON_NAMES[parseInt(item.sku, 10)] || `weapon_${item.sku}`
+            const action = item.qty > 0 ? "bought" : "sold"
+            return `${action} ${Math.abs(item.qty)}x ${weaponName} @ ${item.price}`
+        })
+
+        logger.info(
+            { ...ctx, totalCost, newCoins, itemCount: validatedItems.length },
+            `Internal buy: ${itemDetails.join(", ")}`
+        )
+
+        return res.json({
+            type: "ibya",
+            rc: BUY_ERROR.SUCCESS,
+            u: buildUserResponse(user, weapons),
+        })
+    } catch (error) {
+        await conn.rollback()
+        logger.error(ctx, "Internal buy error:", error.message)
+        return res.json({
+            type: "ibya",
+            rc: BUY_ERROR.DENIED,
+            msg: { text: "Server error" },
+        })
+    } finally {
+        conn.release()
+    }
+}
+
 module.exports = {
     getItemsList,
     getInventory,
     addCoins,
     getCoins,
+    internalBuy,
     // Exported for testing
     serializeInventoryItem,
+    buildUserResponse,
+    BUY_ERROR,
+    WEAPON_NAMES,
 }

--- a/services/navalclash/shopService.js
+++ b/services/navalclash/shopService.js
@@ -389,10 +389,16 @@ async function internalBuy(req, res) {
             `Internal buy: ${itemDetails.join(", ")}`
         )
 
+        const userResponse = buildUserResponse(user, weapons)
+        logger.debug(
+            { ...ctx, we: weapons, coins: newCoins, encodedCoins: userResponse.an },
+            "Sending ibya response"
+        )
+
         return res.json({
             type: "ibya",
             rc: BUY_ERROR.SUCCESS,
-            u: buildUserResponse(user, weapons),
+            u: userResponse,
         })
     } catch (error) {
         await conn.rollback()

--- a/services/navalclash/shopService.js
+++ b/services/navalclash/shopService.js
@@ -61,7 +61,10 @@ async function getItemsList(req, res) {
              ORDER BY sort_order, weapon_index`
         )
 
-        logger.debug({ ...ctx, itemCount: items.length }, "Returning armory items")
+        logger.debug(
+            { ...ctx, itemCount: items.length },
+            "Returning armory items"
+        )
 
         // Format items for client response
         const formattedItems = items.map((item) => ({
@@ -118,7 +121,10 @@ async function getInventory(req, res) {
 
         const coins = users.length > 0 ? users[0].coins : 0
 
-        logger.debug({ ...ctx, itemCount: items.length, coins }, "Returning inventory")
+        logger.debug(
+            { ...ctx, itemCount: items.length, coins },
+            "Returning inventory"
+        )
         return res.json({
             type: "inventory",
             coins: coins,
@@ -222,7 +228,11 @@ async function internalBuy(req, res) {
     const { u, lg, tkn, its } = req.body
     const ctx = { reqId: req.requestId }
 
-    logger.debug(ctx, "Internal buy request", { lg, hasUser: !!u, itemCount: its?.length })
+    logger.debug(ctx, "Internal buy request", {
+        lg,
+        hasUser: !!u,
+        itemCount: its?.length,
+    })
 
     // Validate request
     if (!u || !u.id) {
@@ -274,7 +284,9 @@ async function internalBuy(req, res) {
         const [shopItems] = await conn.execute(
             "SELECT weapon_index, price FROM shop_items WHERE is_active = 1"
         )
-        const priceMap = new Map(shopItems.map((item) => [String(item.weapon_index), item.price]))
+        const priceMap = new Map(
+            shopItems.map((item) => [String(item.weapon_index), item.price])
+        )
 
         // Validate prices and calculate total cost
         let totalCost = 0
@@ -297,7 +309,10 @@ async function internalBuy(req, res) {
             // Validate price matches server
             if (p !== serverPrice) {
                 await conn.rollback()
-                logger.warn({ ...ctx, sku, clientPrice: p, serverPrice }, "Internal buy price mismatch")
+                logger.warn(
+                    { ...ctx, sku, clientPrice: p, serverPrice },
+                    "Internal buy price mismatch"
+                )
                 return res.json({
                     type: "ibya",
                     rc: BUY_ERROR.WRONG_PRICE,
@@ -314,7 +329,10 @@ async function internalBuy(req, res) {
         // Check if user has enough coins
         if (totalCost > user.coins) {
             await conn.rollback()
-            logger.warn({ ...ctx, totalCost, userCoins: user.coins }, "Internal buy insufficient coins")
+            logger.warn(
+                { ...ctx, totalCost, userCoins: user.coins },
+                "Internal buy insufficient coins"
+            )
             return res.json({
                 type: "ibya",
                 rc: BUY_ERROR.WRONG_PRICE,
@@ -324,7 +342,10 @@ async function internalBuy(req, res) {
 
         // Deduct coins
         const newCoins = user.coins - totalCost
-        await conn.execute("UPDATE users SET coins = ? WHERE id = ?", [newCoins, user.id])
+        await conn.execute("UPDATE users SET coins = ? WHERE id = ?", [
+            newCoins,
+            user.id,
+        ])
 
         // Update inventory for each item
         for (const item of validatedItems) {
@@ -370,7 +391,8 @@ async function internalBuy(req, res) {
 
         // Log each item purchased with name, qty, price
         const itemDetails = validatedItems.map((item) => {
-            const weaponName = WEAPON_NAMES[parseInt(item.sku, 10)] || `weapon_${item.sku}`
+            const weaponName =
+                WEAPON_NAMES[parseInt(item.sku, 10)] || `weapon_${item.sku}`
             const action = item.qty > 0 ? "bought" : "sold"
             return `${action} ${Math.abs(item.qty)}x ${weaponName} @ ${item.price}`
         })
@@ -382,7 +404,12 @@ async function internalBuy(req, res) {
 
         const userResponse = buildUserResponse(user, weapons)
         logger.debug(
-            { ...ctx, we: weapons, coins: newCoins, encodedCoins: userResponse.an },
+            {
+                ...ctx,
+                we: weapons,
+                coins: newCoins,
+                encodedCoins: userResponse.an,
+            },
             "Sending ibya response"
         )
 

--- a/services/navalclash/shopService.test.js
+++ b/services/navalclash/shopService.test.js
@@ -205,8 +205,18 @@ describe("services/navalclash/shopService", () => {
             mockExecute
                 .mockResolvedValueOnce([
                     [
-                        { item_type: "weapon", item_id: "torpedo", quantity: 3, times_used: 1 },
-                        { item_type: "skin", item_id: "camo", quantity: 1, times_used: 0 },
+                        {
+                            item_type: "weapon",
+                            item_id: "torpedo",
+                            quantity: 3,
+                            times_used: 1,
+                        },
+                        {
+                            item_type: "skin",
+                            item_id: "camo",
+                            quantity: 1,
+                            times_used: 0,
+                        },
                     ],
                 ])
                 .mockResolvedValueOnce([[{ coins: 500 }]])
@@ -224,9 +234,7 @@ describe("services/navalclash/shopService", () => {
         })
 
         it("should return 0 coins if user not found", async () => {
-            mockExecute
-                .mockResolvedValueOnce([[]])
-                .mockResolvedValueOnce([[]])
+            mockExecute.mockResolvedValueOnce([[]]).mockResolvedValueOnce([[]])
 
             const req = { requestId: "test", body: { uid: 999 } }
 
@@ -337,7 +345,10 @@ describe("services/navalclash/shopService", () => {
         })
 
         it("should return error if missing user", async () => {
-            const req = { requestId: "test", body: { its: [{ sku: "0", q: 1, p: 50 }] } }
+            const req = {
+                requestId: "test",
+                body: { its: [{ sku: "0", q: 1, p: 50 }] },
+            }
 
             await internalBuy(req, mockRes)
 
@@ -382,7 +393,12 @@ describe("services/navalclash/shopService", () => {
         })
 
         it("should return error if price mismatch", async () => {
-            const mockUser = { id: 1, name: "Player", uuid: "test-uuid", coins: 500 }
+            const mockUser = {
+                id: 1,
+                name: "Player",
+                uuid: "test-uuid",
+                coins: 500,
+            }
 
             mockConnection.execute
                 .mockResolvedValueOnce([[mockUser]]) // User found
@@ -407,7 +423,12 @@ describe("services/navalclash/shopService", () => {
         })
 
         it("should return error if insufficient coins", async () => {
-            const mockUser = { id: 1, name: "Player", uuid: "test-uuid", coins: 100 }
+            const mockUser = {
+                id: 1,
+                name: "Player",
+                uuid: "test-uuid",
+                coins: 100,
+            }
 
             mockConnection.execute
                 .mockResolvedValueOnce([[mockUser]]) // User found
@@ -445,7 +466,12 @@ describe("services/navalclash/shopService", () => {
 
             mockConnection.execute
                 .mockResolvedValueOnce([[mockUser]]) // User found
-                .mockResolvedValueOnce([[{ weapon_index: 0, price: 50 }, { weapon_index: 1, price: 75 }]]) // Shop items
+                .mockResolvedValueOnce([
+                    [
+                        { weapon_index: 0, price: 50 },
+                        { weapon_index: 1, price: 75 },
+                    ],
+                ]) // Shop items
                 .mockResolvedValueOnce([{ affectedRows: 1 }]) // Update coins
                 .mockResolvedValueOnce([{ affectedRows: 1 }]) // Insert inventory
                 .mockResolvedValueOnce([[{ item_id: "0", quantity: 3 }]]) // Get inventory
@@ -512,7 +538,12 @@ describe("services/navalclash/shopService", () => {
         })
 
         it("should return error for invalid SKU", async () => {
-            const mockUser = { id: 1, name: "Player", uuid: "test-uuid", coins: 500 }
+            const mockUser = {
+                id: 1,
+                name: "Player",
+                uuid: "test-uuid",
+                coins: 500,
+            }
 
             mockConnection.execute
                 .mockResolvedValueOnce([[mockUser]]) // User found

--- a/services/navalclash/socialService.js
+++ b/services/navalclash/socialService.js
@@ -715,10 +715,13 @@ async function userMarker(req, res) {
                     logger.info(ctx, "Session closed (player left matchmaking)")
                 }
             } else {
-                // Keep session fresh
+                // Keep session fresh — update per-player last_seen
+                const player = Number(sessionId & 1n)
+                const column =
+                    player === 0 ? "last_seen_one" : "last_seen_two"
                 await pool.execute(
                     `UPDATE game_sessions
-                     SET updated_at = NOW(3)
+                     SET ${column} = NOW(3)
                      WHERE id = ? AND status IN (0, 1)`,
                     [baseSessionId.toString()]
                 )

--- a/services/navalclash/socialService.js
+++ b/services/navalclash/socialService.js
@@ -50,6 +50,9 @@ function serializeRival(row) {
         v: row.version || 0, // Version
         f: row.face || 0, // Face/avatar
         s: lastSeenSecondsAgo, // Last seen (seconds ago)
+        gp: row.gp || 0, // Game played timestamp (seconds) - overridden by callers with real data
+        iw: row.iw || 0, // I won flag - overridden by callers with real data
+        t: 0,
         uid: row.uuid || "", // UUID
     }
 }
@@ -202,12 +205,22 @@ async function getRivals(req, res) {
         const [rows] = await pool.execute(
             `SELECT ul.list_type, ul.rival_id,
                     u.id, u.name, u.face, u.rank, u.stars, u.games, u.gameswon,
-                    u.uuid, u.status, u.lang, u.version, u.updated_at as lastseen
+                    u.uuid, u.status, u.lang, u.version, u.updated_at as lastseen,
+                    lg.played_at, lg.winner_id
              FROM userlists ul
              JOIN users u ON u.id = ul.rival_id
+             LEFT JOIN LATERAL (
+                 SELECT gs.created_at as played_at, gs.winner_id
+                 FROM game_sessions gs
+                 WHERE ((gs.user_one_id = ? AND gs.user_two_id = ul.rival_id)
+                    OR  (gs.user_two_id = ? AND gs.user_one_id = ul.rival_id))
+                   AND gs.status >= 10
+                 ORDER BY gs.created_at DESC
+                 LIMIT 1
+             ) lg ON TRUE
              WHERE ul.user_id = ?
              ORDER BY ul.list_type, u.name`,
-            [user.id]
+            [user.id, user.id, user.id]
         )
 
         // Return all rivals with their type (mapped to client constants)
@@ -218,6 +231,10 @@ async function getRivals(req, res) {
                 row.list_type === LIST_TYPE.FRIENDS
                     ? RIVAL_TYPE.SAVED
                     : RIVAL_TYPE.REJECTED,
+            gp: row.played_at
+                ? Math.floor(new Date(row.played_at).getTime() / 1000)
+                : 0,
+            iw: row.winner_id === user.id ? 1 : 0,
         }))
 
         logger.debug(ctx, `Returning ${rivals.length} rivals`)
@@ -414,6 +431,11 @@ async function getOnlineUsers(req, res) {
             v: row.version || 0,
             f: row.face || 0,
             s: row.last_seen, // -1=playing, -2=setup, >0=seconds ago
+            gp: row.created_at
+                ? Math.floor(new Date(row.created_at).getTime() / 1000)
+                : 0, // Session creation time (seconds)
+            iw: 0, // No win/loss for active sessions
+            t: 0,
             uid: row.uuid || "",
             sid: row.is_playing ? null : row.session_id.toString(), // Session ID only for waiting users
             ip: row.is_playing, // Is playing flag

--- a/services/navalclash/socialService.js
+++ b/services/navalclash/socialService.js
@@ -31,23 +31,26 @@ function serializeRival(row) {
         const date = row.lastseen || row.updated_at
         const lastSeenTime = new Date(date).getTime()
         const now = Date.now()
-        lastSeenSecondsAgo = Math.max(0, Math.floor((now - lastSeenTime) / 1000))
+        lastSeenSecondsAgo = Math.max(
+            0,
+            Math.floor((now - lastSeenTime) / 1000)
+        )
     }
 
     return {
-        type: "rnf",                    // Required - client checks this first!
-        id: row.id,                     // User's database ID
-        rid: row.rival_id || row.id,    // Rival ID for list operations
-        n: row.name,                    // Name
-        r: row.rank || 0,               // Rank
-        l: row.lang || "--",            // Language
-        g: row.games || 0,              // Games played
-        gw: row.gameswon || 0,          // Games won
-        d: row.device || "",            // Device name
-        v: row.version || 0,            // Version
-        f: row.face || 0,               // Face/avatar
-        s: lastSeenSecondsAgo,          // Last seen (seconds ago)
-        uid: row.uuid || "",            // UUID
+        type: "rnf", // Required - client checks this first!
+        id: row.id, // User's database ID
+        rid: row.rival_id || row.id, // Rival ID for list operations
+        n: row.name, // Name
+        r: row.rank || 0, // Rank
+        l: row.lang || "--", // Language
+        g: row.games || 0, // Games played
+        gw: row.gameswon || 0, // Games won
+        d: row.device || "", // Device name
+        v: row.version || 0, // Version
+        f: row.face || 0, // Face/avatar
+        s: lastSeenSecondsAgo, // Last seen (seconds ago)
+        uid: row.uuid || "", // UUID
     }
 }
 
@@ -95,7 +98,8 @@ async function addRival(req, res) {
     }
 
     ctx.uid = user.id
-    const listType = tp === LIST_TYPE.BLOCKED ? LIST_TYPE.BLOCKED : LIST_TYPE.FRIENDS
+    const listType =
+        tp === LIST_TYPE.BLOCKED ? LIST_TYPE.BLOCKED : LIST_TYPE.FRIENDS
 
     try {
         await pool.execute(
@@ -104,7 +108,10 @@ async function addRival(req, res) {
              ON DUPLICATE KEY UPDATE list_type = VALUES(list_type)`,
             [user.id, listType, rid]
         )
-        logger.info(ctx, `Rival added to ${listType === LIST_TYPE.BLOCKED ? "blocked" : "friends"} list`)
+        logger.info(
+            ctx,
+            `Rival added to ${listType === LIST_TYPE.BLOCKED ? "blocked" : "friends"} list`
+        )
         return res.json({ type: "uok" })
     } catch (error) {
         logger.error(ctx, "addRival error:", error.message)
@@ -142,14 +149,18 @@ async function deleteRival(req, res) {
     }
 
     ctx.uid = user.id
-    const listType = tp === LIST_TYPE.BLOCKED ? LIST_TYPE.BLOCKED : LIST_TYPE.FRIENDS
+    const listType =
+        tp === LIST_TYPE.BLOCKED ? LIST_TYPE.BLOCKED : LIST_TYPE.FRIENDS
 
     try {
         await pool.execute(
             "DELETE FROM userlists WHERE user_id = ? AND rival_id = ? AND list_type = ?",
             [user.id, rid, listType]
         )
-        logger.info(ctx, `Rival removed from ${listType === LIST_TYPE.BLOCKED ? "blocked" : "friends"} list`)
+        logger.info(
+            ctx,
+            `Rival removed from ${listType === LIST_TYPE.BLOCKED ? "blocked" : "friends"} list`
+        )
         return res.json({ type: "uok" })
     } catch (error) {
         logger.error(ctx, "deleteRival error:", error.message)
@@ -203,7 +214,10 @@ async function getRivals(req, res) {
         const rivals = rows.map((row) => ({
             ...serializeRival(row),
             // Map list_type (1=friends, 2=blocked) to RivalInfo type (3=saved, 4=rejected)
-            t: row.list_type === LIST_TYPE.FRIENDS ? RIVAL_TYPE.SAVED : RIVAL_TYPE.REJECTED,
+            t:
+                row.list_type === LIST_TYPE.FRIENDS
+                    ? RIVAL_TYPE.SAVED
+                    : RIVAL_TYPE.REJECTED,
         }))
 
         logger.debug(ctx, `Returning ${rivals.length} rivals`)
@@ -329,12 +343,15 @@ async function getRecentOpponents(req, res) {
 
         const opponents = rows.map((row) => ({
             ...serializeRival(row),
-            t: RIVAL_TYPE.RECENT,                           // Type = recent opponent
-            iw: row.winner_id === user.id ? 1 : 0,              // I won flag
-            gp: Math.floor(new Date(row.played_at).getTime() / 1000),  // Game played time (seconds)
+            t: RIVAL_TYPE.RECENT, // Type = recent opponent
+            iw: row.winner_id === user.id ? 1 : 0, // I won flag
+            gp: Math.floor(new Date(row.played_at).getTime() / 1000), // Game played time (seconds)
         }))
 
-        logger.debug({ ...ctx, count: opponents.length }, "Returning recent opponents")
+        logger.debug(
+            { ...ctx, count: opponents.length },
+            "Returning recent opponents"
+        )
         return res.json({ type: "urcnt", ar: opponents })
     } catch (error) {
         logger.error(ctx, "getRecentOpponents error:", error.message)
@@ -396,10 +413,10 @@ async function getOnlineUsers(req, res) {
             d: "",
             v: row.version || 0,
             f: row.face || 0,
-            s: row.last_seen,                               // -1=playing, -2=setup, >0=seconds ago
+            s: row.last_seen, // -1=playing, -2=setup, >0=seconds ago
             uid: row.uuid || "",
-            sid: row.is_playing ? null : row.session_id.toString(),  // Session ID only for waiting users
-            ip: row.is_playing,                             // Is playing flag
+            sid: row.is_playing ? null : row.session_id.toString(), // Session ID only for waiting users
+            ip: row.is_playing, // Is playing flag
         }))
 
         logger.debug({ ...ctx, count: users.length }, "Returning online users")
@@ -409,7 +426,6 @@ async function getOnlineUsers(req, res) {
         return res.json({ type: "error", reason: "Database error" })
     }
 }
-
 
 /**
  * Checks if someone is waiting to play with a specific user (personal game invitation).
@@ -571,10 +587,13 @@ async function findUserBySession(sessionId) {
 
         if (sessions.length === 0) return null
 
-        const userId = player === 0 ? sessions[0].user_one_id : sessions[0].user_two_id
+        const userId =
+            player === 0 ? sessions[0].user_one_id : sessions[0].user_two_id
         if (!userId) return null
 
-        const [users] = await pool.execute("SELECT * FROM users WHERE id = ?", [userId])
+        const [users] = await pool.execute("SELECT * FROM users WHERE id = ?", [
+            userId,
+        ])
         return users.length > 0 ? users[0] : null
     } catch (error) {
         return null
@@ -623,7 +642,10 @@ async function userMarker(req, res) {
     if (!user) {
         // User hasn't connected yet - this is normal for first-time users
         // They'll be created during /connect, just return ok silently
-        logger.debug(ctx, "User marker - user not found (will be created on connect)")
+        logger.debug(
+            ctx,
+            "User marker - user not found (will be created on connect)"
+        )
         return res.json({ type: "uok" })
     }
 
@@ -643,7 +665,11 @@ async function userMarker(req, res) {
             const invitation = await findPendingInvitation(user.id, gameVariant)
             if (invitation) {
                 logger.info(
-                    { ...ctx, inviterId: invitation.inviter.id, inviterSid: invitation.sessionId },
+                    {
+                        ...ctx,
+                        inviterId: invitation.inviter.id,
+                        inviterSid: invitation.sessionId,
+                    },
                     `Found pending invitation from ${invitation.inviter.name}`
                 )
 
@@ -803,7 +829,9 @@ async function userAnswer(req, res) {
 
         // Build the info message to send to the inviter
         // Format: { type: "msg", m: <msgId>, p: [<params>], c: <needConfirm> }
-        const msgId = ans ? MSG.PERSONAL_RIVAL_ACCEPTED : MSG.PERSONAL_RIVAL_REJECTED
+        const msgId = ans
+            ? MSG.PERSONAL_RIVAL_ACCEPTED
+            : MSG.PERSONAL_RIVAL_REJECTED
         const infoMessage = {
             type: "msg",
             m: msgId,

--- a/services/navalclash/socialService.test.js
+++ b/services/navalclash/socialService.test.js
@@ -123,6 +123,8 @@ describe("services/navalclash/socialService", () => {
                 l: "--",
                 g: 30,
                 gw: 15,
+                gp: 0,
+                iw: 0,
                 d: "",
                 v: 0,
                 s: 0,

--- a/services/navalclash/socialService.test.js
+++ b/services/navalclash/socialService.test.js
@@ -283,7 +283,10 @@ describe("services/navalclash/socialService", () => {
 
             await getRivals(req, mockRes)
 
-            expect(mockRes.json).toHaveBeenCalledWith({ type: "usaved", ar: [] })
+            expect(mockRes.json).toHaveBeenCalledWith({
+                type: "usaved",
+                ar: [],
+            })
         })
 
         it("should return rivals with list type", async () => {
@@ -455,7 +458,9 @@ describe("services/navalclash/socialService", () => {
             expect(response.ar[0].iw).toBe(1) // user id=1 won
             expect(response.ar[1].iw).toBe(0) // user id=1 lost
             expect(response.ar[0].t).toBe(2) // TYPE_RECENT
-            expect(response.ar[0].gp).toBe(Math.floor(playedAt.getTime() / 1000)) // game played time
+            expect(response.ar[0].gp).toBe(
+                Math.floor(playedAt.getTime() / 1000)
+            ) // game played time
         })
     })
 
@@ -475,7 +480,7 @@ describe("services/navalclash/socialService", () => {
                         session_id: 1000n,
                         name: "WaitingUser",
                         face: 1,
-                        last_seen: -2,  // Setting up
+                        last_seen: -2, // Setting up
                         is_playing: 0,
                     },
                 ],
@@ -493,8 +498,8 @@ describe("services/navalclash/socialService", () => {
             expect(response.type).toBe("uair")
             expect(response.ar).toHaveLength(1)
             expect(response.ar[0].sid).toBe("1000")
-            expect(response.ar[0].s).toBe(-2)  // Setting up
-            expect(response.ar[0].ip).toBe(0)  // Not playing
+            expect(response.ar[0].s).toBe(-2) // Setting up
+            expect(response.ar[0].ip).toBe(0) // Not playing
         })
 
         it("should exclude current user from online list", async () => {
@@ -530,7 +535,7 @@ describe("services/navalclash/socialService", () => {
                         session_id: 1000n,
                         name: "PlayingUser",
                         face: 1,
-                        last_seen: -1,  // Currently playing
+                        last_seen: -1, // Currently playing
                         is_playing: 1,
                     },
                 ],
@@ -541,9 +546,9 @@ describe("services/navalclash/socialService", () => {
             await getOnlineUsers(req, mockRes)
 
             const response = mockRes.json.mock.calls[0][0]
-            expect(response.ar[0].sid).toBeNull()  // No session ID for playing users
-            expect(response.ar[0].s).toBe(-1)  // Currently playing
-            expect(response.ar[0].ip).toBe(1)  // Is playing
+            expect(response.ar[0].sid).toBeNull() // No session ID for playing users
+            expect(response.ar[0].s).toBe(-1) // Currently playing
+            expect(response.ar[0].ip).toBe(1) // Is playing
         })
     })
 
@@ -691,7 +696,16 @@ describe("services/navalclash/socialService", () => {
         it("should send acceptance message to inviter", async () => {
             mockExecute
                 .mockResolvedValueOnce([
-                    [{ id: 1, name: "Responder", uuid: "resp-uuid", rank: 5, face: 2, isbanned: 0 }],
+                    [
+                        {
+                            id: 1,
+                            name: "Responder",
+                            uuid: "resp-uuid",
+                            rank: 5,
+                            face: 2,
+                            isbanned: 0,
+                        },
+                    ],
                 ]) // User lookup
                 .mockResolvedValueOnce([
                     [{ id: 1000, status: 0, user_one_id: 10 }],
@@ -704,31 +718,34 @@ describe("services/navalclash/socialService", () => {
 
             await userAnswer(req, mockRes)
 
-            expect(mockSendMessage).toHaveBeenCalledWith(
-                1000n,
-                "info",
-                {
-                    msg: {
-                        type: "msg",
-                        m: MSG_PERSONAL_RIVAL_ACCEPTED,
-                        p: ["Responder"],
-                        c: false,
-                    },
-                    u: expect.objectContaining({
-                        nam: "Responder",
-                        i: 1,
-                        rk: 5,
-                        fc: 2,
-                    }),
-                }
-            )
+            expect(mockSendMessage).toHaveBeenCalledWith(1000n, "info", {
+                msg: {
+                    type: "msg",
+                    m: MSG_PERSONAL_RIVAL_ACCEPTED,
+                    p: ["Responder"],
+                    c: false,
+                },
+                u: expect.objectContaining({
+                    nam: "Responder",
+                    i: 1,
+                    rk: 5,
+                    fc: 2,
+                }),
+            })
             expect(mockRes.json).toHaveBeenCalledWith({ type: "uok" })
         })
 
         it("should send rejection message to inviter", async () => {
             mockExecute
                 .mockResolvedValueOnce([
-                    [{ id: 1, name: "Responder", uuid: "resp-uuid", isbanned: 0 }],
+                    [
+                        {
+                            id: 1,
+                            name: "Responder",
+                            uuid: "resp-uuid",
+                            isbanned: 0,
+                        },
+                    ],
                 ]) // User lookup
                 .mockResolvedValueOnce([
                     [{ id: 1000, status: 0, user_one_id: 10 }],

--- a/services/navalclash/weaponService.js
+++ b/services/navalclash/weaponService.js
@@ -1,0 +1,223 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ */
+
+const {
+    dbGetUserWeaponInventory,
+    dbSetTrackedWeapons,
+    dbGetTrackedWeapons,
+    dbIncrementWeaponUsage,
+    dbConsumeWeapons,
+    dbGetSessionUserId,
+} = require("../../db/navalclash/weapons")
+const { logger } = require("../../utils/logger")
+
+/**
+ * Weapon type ID mapping.
+ * Maps weapon codes to numeric IDs used in inventory.
+ */
+const WEAPON_CODE_TO_ID = {
+    wmn: "0", // Mine
+    mine: "0",
+    dch: "1", // Dutch
+    dutch: "1",
+    anr: "2", // Radar
+    radar: "2",
+    smw: "3", // Shuffle
+    shuffle: "3",
+    sth: "4", // Stealth
+    stealth: "4",
+    cls: "5", // Classic shield
+    cshield: "5",
+}
+
+/**
+ * Weapon ID to name mapping for logging.
+ */
+const WEAPON_ID_TO_NAME = {
+    0: "mine",
+    1: "dutch",
+    2: "radar",
+    3: "shuffle",
+    4: "stealth",
+    5: "cshield",
+}
+
+/**
+ * Converts weapon code to inventory item ID.
+ *
+ * @param {string} code - Weapon code (e.g., 'wmn', 'dch')
+ * @returns {string|null} Inventory item ID or null if unknown
+ */
+function weaponCodeToId(code) {
+    if (!code) return null
+    const normalized = code.toLowerCase()
+    return WEAPON_CODE_TO_ID[normalized] || null
+}
+
+/**
+ * Counts weapons by type from a weapon placement array.
+ *
+ * @param {Array} weapons - Array of weapon objects with 'type' field
+ * @returns {Object} Map of weaponId -> count
+ */
+function countWeaponsByType(weapons) {
+    const counts = {}
+    if (!weapons || !Array.isArray(weapons)) {
+        return counts
+    }
+    for (const weapon of weapons) {
+        const id = weaponCodeToId(weapon.type)
+        if (id !== null) {
+            counts[id] = (counts[id] || 0) + 1
+        }
+    }
+    return counts
+}
+
+/**
+ * Validates weapon placement against user's inventory.
+ *
+ * @param {Array} weapons - Array of weapon objects from wpl message
+ * @param {number} userId - User ID
+ * @param {Object} ctx - Logging context
+ * @returns {Promise<Object>} { valid: boolean, error?: string, counts?: Object }
+ */
+async function validateWeaponPlacement(weapons, userId, ctx) {
+    const counts = countWeaponsByType(weapons)
+    const inventory = await dbGetUserWeaponInventory(userId)
+
+    logger.debug(
+        { ...ctx, userId, counts, inventory },
+        "Validating weapon placement"
+    )
+
+    // Check each weapon type against inventory
+    for (const [weaponId, needed] of Object.entries(counts)) {
+        const available = inventory[weaponId] || 0
+        const weaponName = WEAPON_ID_TO_NAME[weaponId] || weaponId
+        if (needed > available) {
+            const error = `Insufficient ${weaponName}: need ${needed}, have ${available}`
+            logger.warn({ ...ctx, userId, weaponId, needed, available }, error)
+            return { valid: false, error }
+        }
+    }
+
+    return { valid: true, counts }
+}
+
+/**
+ * Tracks weapon placement for a session.
+ * Does NOT consume weapons - that happens at game end.
+ *
+ * @param {BigInt} baseSessionId - Base session ID
+ * @param {number} player - Player number (0 or 1)
+ * @param {Object} weaponCounts - Map of weaponId -> count
+ * @param {Object} ctx - Logging context
+ * @returns {Promise<boolean>} True if successful
+ */
+async function trackWeaponPlacement(baseSessionId, player, weaponCounts, ctx) {
+    const result = await dbSetTrackedWeapons(baseSessionId, player, weaponCounts)
+    if (result) {
+        logger.debug(
+            { ...ctx, player, weaponCounts },
+            "Weapons tracked for session"
+        )
+    } else {
+        logger.error({ ...ctx, player }, "Failed to track weapons")
+    }
+    return result
+}
+
+/**
+ * Tracks radar usage for a session.
+ *
+ * @param {BigInt} baseSessionId - Base session ID
+ * @param {number} player - Player number (0 or 1)
+ * @param {Object} ctx - Logging context
+ * @returns {Promise<boolean>} True if successful
+ */
+async function trackRadarUsage(baseSessionId, player, ctx) {
+    const result = await dbIncrementWeaponUsage(baseSessionId, player, "radar")
+    if (result) {
+        logger.debug({ ...ctx, player }, "Radar usage tracked")
+    }
+    return result
+}
+
+/**
+ * Tracks shuffle (ship move) usage for a session.
+ *
+ * @param {BigInt} baseSessionId - Base session ID
+ * @param {number} player - Player number (0 or 1)
+ * @param {Object} ctx - Logging context
+ * @returns {Promise<boolean>} True if successful
+ */
+async function trackShuffleUsage(baseSessionId, player, ctx) {
+    const result = await dbIncrementWeaponUsage(
+        baseSessionId,
+        player,
+        "shuffle"
+    )
+    if (result) {
+        logger.debug({ ...ctx, player }, "Shuffle usage tracked")
+    }
+    return result
+}
+
+/**
+ * Consumes loser's weapons at game end.
+ * Winner keeps their weapons (no consumption).
+ *
+ * @param {BigInt} baseSessionId - Base session ID
+ * @param {number} loserPlayer - Loser's player number (0 or 1)
+ * @param {Object} conn - Database connection (for transaction)
+ * @param {Object} ctx - Logging context
+ * @returns {Promise<boolean>} True if successful
+ */
+async function consumeLoserWeapons(baseSessionId, loserPlayer, conn, ctx) {
+    // Get loser's user ID
+    const loserId = await dbGetSessionUserId(baseSessionId, loserPlayer)
+    if (!loserId) {
+        logger.warn({ ...ctx, loserPlayer }, "Loser user ID not found")
+        return true // Not an error - game can still finish
+    }
+
+    // Get tracked weapons for loser
+    const tracked = await dbGetTrackedWeapons(baseSessionId, loserPlayer)
+    if (!tracked || Object.keys(tracked).length === 0) {
+        logger.debug(
+            { ...ctx, loserPlayer, loserId },
+            "No weapons to consume for loser"
+        )
+        return true
+    }
+
+    // Consume weapons from loser's inventory
+    const result = await dbConsumeWeapons(loserId, tracked, conn)
+    if (result) {
+        logger.info(
+            { ...ctx, loserId, loserPlayer, tracked },
+            "Loser weapons consumed"
+        )
+    } else {
+        logger.error({ ...ctx, loserId }, "Failed to consume loser weapons")
+    }
+    return result
+}
+
+module.exports = {
+    // Constants
+    WEAPON_CODE_TO_ID,
+    WEAPON_ID_TO_NAME,
+    // Functions
+    weaponCodeToId,
+    countWeaponsByType,
+    validateWeaponPlacement,
+    trackWeaponPlacement,
+    trackRadarUsage,
+    trackShuffleUsage,
+    consumeLoserWeapons,
+}

--- a/services/navalclash/weaponService.js
+++ b/services/navalclash/weaponService.js
@@ -13,37 +13,7 @@ const {
     dbGetSessionUserId,
 } = require("../../db/navalclash/weapons")
 const { logger } = require("../../utils/logger")
-
-/**
- * Weapon type ID mapping.
- * Maps weapon codes to numeric IDs used in inventory.
- */
-const WEAPON_CODE_TO_ID = {
-    wmn: "0", // Mine
-    mine: "0",
-    dch: "1", // Dutch
-    dutch: "1",
-    anr: "2", // Radar
-    radar: "2",
-    smw: "3", // Shuffle
-    shuffle: "3",
-    sth: "4", // Stealth
-    stealth: "4",
-    cls: "5", // Classic shield
-    cshield: "5",
-}
-
-/**
- * Weapon ID to name mapping for logging.
- */
-const WEAPON_ID_TO_NAME = {
-    0: "mine",
-    1: "dutch",
-    2: "radar",
-    3: "shuffle",
-    4: "stealth",
-    5: "cshield",
-}
+const { WEAPON_CODE_TO_ID, WEAPON_ID_TO_NAME } = require("./constants")
 
 /**
  * Converts weapon code to inventory item ID.

--- a/services/navalclash/weaponService.js
+++ b/services/navalclash/weaponService.js
@@ -89,7 +89,11 @@ async function validateWeaponPlacement(weapons, userId, ctx) {
  * @returns {Promise<boolean>} True if successful
  */
 async function trackWeaponPlacement(baseSessionId, player, weaponCounts, ctx) {
-    const result = await dbSetTrackedWeapons(baseSessionId, player, weaponCounts)
+    const result = await dbSetTrackedWeapons(
+        baseSessionId,
+        player,
+        weaponCounts
+    )
     if (result) {
         logger.debug(
             { ...ctx, player, weaponCounts },

--- a/services/navalclash/weaponService.test.js
+++ b/services/navalclash/weaponService.test.js
@@ -1,0 +1,333 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ */
+
+jest.mock("../../db/navalclash/weapons", () => ({
+    dbGetUserWeaponInventory: jest.fn(),
+    dbSetTrackedWeapons: jest.fn(),
+    dbGetTrackedWeapons: jest.fn(),
+    dbIncrementWeaponUsage: jest.fn(),
+    dbConsumeWeapons: jest.fn(),
+    dbGetSessionUserId: jest.fn(),
+}))
+
+const {
+    dbGetUserWeaponInventory,
+    dbSetTrackedWeapons,
+    dbGetTrackedWeapons,
+    dbIncrementWeaponUsage,
+    dbConsumeWeapons,
+    dbGetSessionUserId,
+} = require("../../db/navalclash/weapons")
+
+const {
+    WEAPON_CODE_TO_ID,
+    WEAPON_ID_TO_NAME,
+    weaponCodeToId,
+    countWeaponsByType,
+    validateWeaponPlacement,
+    trackWeaponPlacement,
+    trackRadarUsage,
+    trackShuffleUsage,
+    consumeLoserWeapons,
+} = require("./weaponService")
+
+describe("services/navalclash/weaponService", () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    describe("WEAPON_CODE_TO_ID", () => {
+        it("should map weapon codes to IDs", () => {
+            expect(WEAPON_CODE_TO_ID.wmn).toBe("0")
+            expect(WEAPON_CODE_TO_ID.mine).toBe("0")
+            expect(WEAPON_CODE_TO_ID.dch).toBe("1")
+            expect(WEAPON_CODE_TO_ID.dutch).toBe("1")
+            expect(WEAPON_CODE_TO_ID.anr).toBe("2")
+            expect(WEAPON_CODE_TO_ID.radar).toBe("2")
+            expect(WEAPON_CODE_TO_ID.smw).toBe("3")
+            expect(WEAPON_CODE_TO_ID.shuffle).toBe("3")
+            expect(WEAPON_CODE_TO_ID.sth).toBe("4")
+            expect(WEAPON_CODE_TO_ID.stealth).toBe("4")
+            expect(WEAPON_CODE_TO_ID.cls).toBe("5")
+            expect(WEAPON_CODE_TO_ID.cshield).toBe("5")
+        })
+    })
+
+    describe("WEAPON_ID_TO_NAME", () => {
+        it("should map IDs to names", () => {
+            expect(WEAPON_ID_TO_NAME[0]).toBe("mine")
+            expect(WEAPON_ID_TO_NAME[1]).toBe("dutch")
+            expect(WEAPON_ID_TO_NAME[2]).toBe("radar")
+            expect(WEAPON_ID_TO_NAME[3]).toBe("shuffle")
+            expect(WEAPON_ID_TO_NAME[4]).toBe("stealth")
+            expect(WEAPON_ID_TO_NAME[5]).toBe("cshield")
+        })
+    })
+
+    describe("weaponCodeToId", () => {
+        it("should convert weapon codes to IDs", () => {
+            expect(weaponCodeToId("wmn")).toBe("0")
+            expect(weaponCodeToId("dch")).toBe("1")
+            expect(weaponCodeToId("anr")).toBe("2")
+            expect(weaponCodeToId("smw")).toBe("3")
+            expect(weaponCodeToId("sth")).toBe("4")
+            expect(weaponCodeToId("cls")).toBe("5")
+        })
+
+        it("should handle case insensitivity", () => {
+            expect(weaponCodeToId("WMN")).toBe("0")
+            expect(weaponCodeToId("Dch")).toBe("1")
+            expect(weaponCodeToId("RADAR")).toBe("2")
+        })
+
+        it("should return null for unknown codes", () => {
+            expect(weaponCodeToId("unknown")).toBeNull()
+            expect(weaponCodeToId("xyz")).toBeNull()
+        })
+
+        it("should return null for null/undefined input", () => {
+            expect(weaponCodeToId(null)).toBeNull()
+            expect(weaponCodeToId(undefined)).toBeNull()
+        })
+    })
+
+    describe("countWeaponsByType", () => {
+        it("should count weapons by type", () => {
+            const weapons = [
+                { type: "wmn", startX: 0, startY: 0 },
+                { type: "wmn", startX: 1, startY: 1 },
+                { type: "dch", startX: 2, startY: 2 },
+            ]
+
+            const counts = countWeaponsByType(weapons)
+
+            expect(counts).toEqual({ "0": 2, "1": 1 })
+        })
+
+        it("should return empty object for empty array", () => {
+            expect(countWeaponsByType([])).toEqual({})
+        })
+
+        it("should return empty object for null/undefined", () => {
+            expect(countWeaponsByType(null)).toEqual({})
+            expect(countWeaponsByType(undefined)).toEqual({})
+        })
+
+        it("should skip unknown weapon types", () => {
+            const weapons = [
+                { type: "wmn" },
+                { type: "unknown" },
+                { type: "anr" },
+            ]
+
+            const counts = countWeaponsByType(weapons)
+
+            expect(counts).toEqual({ "0": 1, "2": 1 })
+        })
+    })
+
+    describe("validateWeaponPlacement", () => {
+        it("should return valid when inventory has enough weapons", async () => {
+            dbGetUserWeaponInventory.mockResolvedValue({ "0": 5, "1": 2 })
+
+            const weapons = [
+                { type: "wmn" },
+                { type: "wmn" },
+                { type: "dch" },
+            ]
+            const ctx = { reqId: "test" }
+
+            const result = await validateWeaponPlacement(weapons, 1, ctx)
+
+            expect(result.valid).toBe(true)
+            expect(result.counts).toEqual({ "0": 2, "1": 1 })
+        })
+
+        it("should return invalid when inventory insufficient", async () => {
+            dbGetUserWeaponInventory.mockResolvedValue({ "0": 1, "1": 0 })
+
+            const weapons = [
+                { type: "wmn" },
+                { type: "wmn" },
+                { type: "dch" },
+            ]
+            const ctx = { reqId: "test" }
+
+            const result = await validateWeaponPlacement(weapons, 1, ctx)
+
+            expect(result.valid).toBe(false)
+            expect(result.error).toContain("Insufficient mine")
+        })
+
+        it("should return valid for empty weapons array", async () => {
+            dbGetUserWeaponInventory.mockResolvedValue({})
+
+            const ctx = { reqId: "test" }
+
+            const result = await validateWeaponPlacement([], 1, ctx)
+
+            expect(result.valid).toBe(true)
+            expect(result.counts).toEqual({})
+        })
+
+        it("should handle weapons not in inventory", async () => {
+            dbGetUserWeaponInventory.mockResolvedValue({})
+
+            const weapons = [{ type: "wmn" }]
+            const ctx = { reqId: "test" }
+
+            const result = await validateWeaponPlacement(weapons, 1, ctx)
+
+            expect(result.valid).toBe(false)
+            expect(result.error).toContain("Insufficient mine: need 1, have 0")
+        })
+    })
+
+    describe("trackWeaponPlacement", () => {
+        it("should track weapons successfully", async () => {
+            dbSetTrackedWeapons.mockResolvedValue(true)
+
+            const ctx = { reqId: "test" }
+            const result = await trackWeaponPlacement(
+                1000n,
+                0,
+                { "0": 2, "1": 1 },
+                ctx
+            )
+
+            expect(result).toBe(true)
+            expect(dbSetTrackedWeapons).toHaveBeenCalledWith(
+                1000n,
+                0,
+                { "0": 2, "1": 1 }
+            )
+        })
+
+        it("should return false on failure", async () => {
+            dbSetTrackedWeapons.mockResolvedValue(false)
+
+            const ctx = { reqId: "test" }
+            const result = await trackWeaponPlacement(1000n, 0, {}, ctx)
+
+            expect(result).toBe(false)
+        })
+    })
+
+    describe("trackRadarUsage", () => {
+        it("should track radar usage", async () => {
+            dbIncrementWeaponUsage.mockResolvedValue(true)
+
+            const ctx = { reqId: "test" }
+            const result = await trackRadarUsage(1000n, 0, ctx)
+
+            expect(result).toBe(true)
+            expect(dbIncrementWeaponUsage).toHaveBeenCalledWith(
+                1000n,
+                0,
+                "radar"
+            )
+        })
+
+        it("should return false on failure", async () => {
+            dbIncrementWeaponUsage.mockResolvedValue(false)
+
+            const ctx = { reqId: "test" }
+            const result = await trackRadarUsage(1000n, 0, ctx)
+
+            expect(result).toBe(false)
+        })
+    })
+
+    describe("trackShuffleUsage", () => {
+        it("should track shuffle usage", async () => {
+            dbIncrementWeaponUsage.mockResolvedValue(true)
+
+            const ctx = { reqId: "test" }
+            const result = await trackShuffleUsage(1000n, 1, ctx)
+
+            expect(result).toBe(true)
+            expect(dbIncrementWeaponUsage).toHaveBeenCalledWith(
+                1000n,
+                1,
+                "shuffle"
+            )
+        })
+
+        it("should return false on failure", async () => {
+            dbIncrementWeaponUsage.mockResolvedValue(false)
+
+            const ctx = { reqId: "test" }
+            const result = await trackShuffleUsage(1000n, 0, ctx)
+
+            expect(result).toBe(false)
+        })
+    })
+
+    describe("consumeLoserWeapons", () => {
+        const mockConn = { execute: jest.fn() }
+
+        it("should consume loser weapons", async () => {
+            dbGetSessionUserId.mockResolvedValue(10)
+            dbGetTrackedWeapons.mockResolvedValue({ "0": 2, "1": 1 })
+            dbConsumeWeapons.mockResolvedValue(true)
+
+            const ctx = { reqId: "test" }
+            const result = await consumeLoserWeapons(1000n, 0, mockConn, ctx)
+
+            expect(result).toBe(true)
+            expect(dbGetSessionUserId).toHaveBeenCalledWith(1000n, 0)
+            expect(dbGetTrackedWeapons).toHaveBeenCalledWith(1000n, 0)
+            expect(dbConsumeWeapons).toHaveBeenCalledWith(
+                10,
+                { "0": 2, "1": 1 },
+                mockConn
+            )
+        })
+
+        it("should return true if no user ID found", async () => {
+            dbGetSessionUserId.mockResolvedValue(null)
+
+            const ctx = { reqId: "test" }
+            const result = await consumeLoserWeapons(1000n, 0, mockConn, ctx)
+
+            expect(result).toBe(true)
+            expect(dbConsumeWeapons).not.toHaveBeenCalled()
+        })
+
+        it("should return true if no tracked weapons", async () => {
+            dbGetSessionUserId.mockResolvedValue(10)
+            dbGetTrackedWeapons.mockResolvedValue(null)
+
+            const ctx = { reqId: "test" }
+            const result = await consumeLoserWeapons(1000n, 0, mockConn, ctx)
+
+            expect(result).toBe(true)
+            expect(dbConsumeWeapons).not.toHaveBeenCalled()
+        })
+
+        it("should return true if tracked weapons is empty", async () => {
+            dbGetSessionUserId.mockResolvedValue(10)
+            dbGetTrackedWeapons.mockResolvedValue({})
+
+            const ctx = { reqId: "test" }
+            const result = await consumeLoserWeapons(1000n, 0, mockConn, ctx)
+
+            expect(result).toBe(true)
+            expect(dbConsumeWeapons).not.toHaveBeenCalled()
+        })
+
+        it("should return false if consumption fails", async () => {
+            dbGetSessionUserId.mockResolvedValue(10)
+            dbGetTrackedWeapons.mockResolvedValue({ "0": 1 })
+            dbConsumeWeapons.mockResolvedValue(false)
+
+            const ctx = { reqId: "test" }
+            const result = await consumeLoserWeapons(1000n, 0, mockConn, ctx)
+
+            expect(result).toBe(false)
+        })
+    })
+})

--- a/services/navalclash/weaponService.test.js
+++ b/services/navalclash/weaponService.test.js
@@ -104,7 +104,7 @@ describe("services/navalclash/weaponService", () => {
 
             const counts = countWeaponsByType(weapons)
 
-            expect(counts).toEqual({ "0": 2, "1": 1 })
+            expect(counts).toEqual({ 0: 2, 1: 1 })
         })
 
         it("should return empty object for empty array", () => {
@@ -125,35 +125,27 @@ describe("services/navalclash/weaponService", () => {
 
             const counts = countWeaponsByType(weapons)
 
-            expect(counts).toEqual({ "0": 1, "2": 1 })
+            expect(counts).toEqual({ 0: 1, 2: 1 })
         })
     })
 
     describe("validateWeaponPlacement", () => {
         it("should return valid when inventory has enough weapons", async () => {
-            dbGetUserWeaponInventory.mockResolvedValue({ "0": 5, "1": 2 })
+            dbGetUserWeaponInventory.mockResolvedValue({ 0: 5, 1: 2 })
 
-            const weapons = [
-                { type: "wmn" },
-                { type: "wmn" },
-                { type: "dch" },
-            ]
+            const weapons = [{ type: "wmn" }, { type: "wmn" }, { type: "dch" }]
             const ctx = { reqId: "test" }
 
             const result = await validateWeaponPlacement(weapons, 1, ctx)
 
             expect(result.valid).toBe(true)
-            expect(result.counts).toEqual({ "0": 2, "1": 1 })
+            expect(result.counts).toEqual({ 0: 2, 1: 1 })
         })
 
         it("should return invalid when inventory insufficient", async () => {
-            dbGetUserWeaponInventory.mockResolvedValue({ "0": 1, "1": 0 })
+            dbGetUserWeaponInventory.mockResolvedValue({ 0: 1, 1: 0 })
 
-            const weapons = [
-                { type: "wmn" },
-                { type: "wmn" },
-                { type: "dch" },
-            ]
+            const weapons = [{ type: "wmn" }, { type: "wmn" }, { type: "dch" }]
             const ctx = { reqId: "test" }
 
             const result = await validateWeaponPlacement(weapons, 1, ctx)
@@ -194,16 +186,15 @@ describe("services/navalclash/weaponService", () => {
             const result = await trackWeaponPlacement(
                 1000n,
                 0,
-                { "0": 2, "1": 1 },
+                { 0: 2, 1: 1 },
                 ctx
             )
 
             expect(result).toBe(true)
-            expect(dbSetTrackedWeapons).toHaveBeenCalledWith(
-                1000n,
-                0,
-                { "0": 2, "1": 1 }
-            )
+            expect(dbSetTrackedWeapons).toHaveBeenCalledWith(1000n, 0, {
+                0: 2,
+                1: 1,
+            })
         })
 
         it("should return false on failure", async () => {
@@ -271,7 +262,7 @@ describe("services/navalclash/weaponService", () => {
 
         it("should consume loser weapons", async () => {
             dbGetSessionUserId.mockResolvedValue(10)
-            dbGetTrackedWeapons.mockResolvedValue({ "0": 2, "1": 1 })
+            dbGetTrackedWeapons.mockResolvedValue({ 0: 2, 1: 1 })
             dbConsumeWeapons.mockResolvedValue(true)
 
             const ctx = { reqId: "test" }
@@ -282,7 +273,7 @@ describe("services/navalclash/weaponService", () => {
             expect(dbGetTrackedWeapons).toHaveBeenCalledWith(1000n, 0)
             expect(dbConsumeWeapons).toHaveBeenCalledWith(
                 10,
-                { "0": 2, "1": 1 },
+                { 0: 2, 1: 1 },
                 mockConn
             )
         })
@@ -321,7 +312,7 @@ describe("services/navalclash/weaponService", () => {
 
         it("should return false if consumption fails", async () => {
             dbGetSessionUserId.mockResolvedValue(10)
-            dbGetTrackedWeapons.mockResolvedValue({ "0": 1 })
+            dbGetTrackedWeapons.mockResolvedValue({ 0: 1 })
             dbConsumeWeapons.mockResolvedValue(false)
 
             const ctx = { reqId: "test" }

--- a/sql/navalclash/003_devices.sql
+++ b/sql/navalclash/003_devices.sql
@@ -4,7 +4,7 @@
 
 CREATE TABLE devices (
     id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    android_id VARCHAR(32) NOT NULL,
+    android_id VARCHAR(64) NOT NULL,
     device VARCHAR(64),
     model VARCHAR(128),
     manufacturer VARCHAR(128),

--- a/sql/navalclash/015_shop_items.sql
+++ b/sql/navalclash/015_shop_items.sql
@@ -1,0 +1,42 @@
+-- Naval Clash - Multiplayer Battleship Game
+-- Copyright (c) 2026 NorthernCaptain
+-- All rights reserved.
+
+-- Drop and recreate shop_items table with correct schema for Armory weapons
+DROP TABLE IF EXISTS shop_items;
+
+-- Game Bonus Coin Rules (for reference - see ONLINE.md for full docs):
+-- Index 0: WIN_BONUS - normal win - winner gets 9 + capped rank delta
+-- Index 1: LOST_BONUS - normal loss - loser gets -1
+-- Index 2: SURRENDER_WIN_BONUS - max(WIN_BONUS/2, 1)
+-- Index 3: SURRENDER_LOST_BONUS - player surrendered - loser gets -2
+-- Index 4: INTERRUPT_WIN_BONUS - opponent disconnected - winner gets 1
+-- Index 5: INTERRUPT_LOST_BONUS - player disconnected - loser gets 0
+-- Index 7: LOST_BONUS_WITH_WEAPONS - loss when using special weapons - loser gets +2
+
+CREATE TABLE shop_items (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    weapon_index TINYINT UNSIGNED NOT NULL COMMENT '0=mine, 1=dutch, 2=radar, 3=shuffle, 4=stealth, 5=cshield',
+    price INT UNSIGNED NOT NULL COMMENT 'Price in coins',
+    min_qty INT UNSIGNED DEFAULT 1 COMMENT 'Minimum purchase quantity',
+    max_qty INT UNSIGNED DEFAULT 99 COMMENT 'Maximum purchase quantity',
+    unlock_price INT UNSIGNED DEFAULT 0 COMMENT 'Price to unlock (0 if already unlocked)',
+    purchase_type CHAR(1) DEFAULT 'I' COMMENT 'I=internal (coins), G=google play',
+    is_active TINYINT DEFAULT 1,
+    sort_order INT DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    UNIQUE KEY idx_weapon (weapon_index),
+    KEY idx_active (is_active, sort_order)
+) ENGINE=InnoDB;
+
+-- Armory weapons purchasable with in-game coins
+-- Weapon indices: 0=mine, 1=dutch (Flying Dutchman), 2=radar, 3=shuffle, 4=stealth, 5=cshield (combat shield)
+INSERT INTO shop_items (weapon_index, price, min_qty, max_qty, unlock_price, purchase_type, sort_order) VALUES
+(0, 50, 1, 99, 0, 'I', 0),   -- Mine
+(1, 75, 1, 99, 0, 'I', 1),   -- Flying Dutchman
+(2, 40, 1, 99, 0, 'I', 2),   -- Radar
+(3, 60, 1, 99, 0, 'I', 3),   -- Shuffle
+(4, 80, 1, 99, 0, 'I', 4),   -- Stealth
+(5, 100, 1, 99, 0, 'I', 5);  -- Combat Shield

--- a/sql/navalclash/016_weapon_tracking.sql
+++ b/sql/navalclash/016_weapon_tracking.sql
@@ -1,0 +1,13 @@
+-- Naval Clash - Multiplayer Battleship Game
+-- Copyright (c) 2026 NorthernCaptain
+-- All rights reserved.
+
+-- Add weapon tracking columns to game_sessions
+-- Weapons are tracked per session (not consumed until game end)
+-- JSON format: { "radar": N, "shuffle": N, "mine": N, "dutch": N, "stealth": N }
+
+ALTER TABLE game_sessions
+ADD COLUMN weapons_tracked_one JSON COMMENT 'Player 0 weapons placed: { weaponId: count }',
+ADD COLUMN weapons_tracked_two JSON COMMENT 'Player 1 weapons placed: { weaponId: count }',
+ADD COLUMN weapons_used_one JSON COMMENT 'Player 0 weapon usage: { radar: N, shuffle: N }',
+ADD COLUMN weapons_used_two JSON COMMENT 'Player 1 weapon usage: { radar: N, shuffle: N }';

--- a/sql/navalclash/017_personal_rival.sql
+++ b/sql/navalclash/017_personal_rival.sql
@@ -1,0 +1,13 @@
+-- Naval Clash - Multiplayer Battleship Game
+-- Copyright (c) 2026 NorthernCaptain
+-- All rights reserved.
+
+-- Add target_rival_id column to game_sessions for personal game invitations
+-- When a player creates a waiting session targeting a specific rival,
+-- the rival's user ID is stored here. The rival can then be notified
+-- via the umarker endpoint and respond via uanswer.
+
+ALTER TABLE game_sessions
+    ADD COLUMN target_rival_id INT UNSIGNED NULL AFTER game_type,
+    ADD KEY idx_target_rival (target_rival_id, status),
+    ADD FOREIGN KEY (target_rival_id) REFERENCES users(id);

--- a/sql/navalclash/018_device_keys.sql
+++ b/sql/navalclash/018_device_keys.sql
@@ -1,0 +1,21 @@
+-- Naval Clash - Multiplayer Battleship Game
+-- Copyright (c) 2026 NorthernCaptain
+-- All rights reserved.
+
+-- Device encryption keys table.
+-- Stores the AES key established during RSA handshake.
+-- Key is associated with a device, not a user.
+
+CREATE TABLE IF NOT EXISTS device_keys (
+    device_token CHAR(44) PRIMARY KEY,       -- Base64 of 32 bytes = 44 chars
+    device_key VARBINARY(32) NOT NULL,       -- Raw AES-256 key (32 bytes)
+    device_uuid VARCHAR(64) NOT NULL,        -- Device UUID from handshake
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP NOT NULL,
+
+    INDEX idx_expires (expires_at),
+    INDEX idx_device (device_uuid)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Cleanup job: run periodically (e.g., every hour via cron)
+-- DELETE FROM device_keys WHERE expires_at < NOW();

--- a/sql/navalclash/019_session_last_seen.sql
+++ b/sql/navalclash/019_session_last_seen.sql
@@ -1,0 +1,22 @@
+-- Naval Clash - Multiplayer Battleship Game
+-- Copyright (c) 2026 NorthernCaptain
+-- All rights reserved.
+
+-- Add per-player last_seen timestamps for stale session detection.
+-- last_seen_one: updated on every poll/send by player 0
+-- last_seen_two: updated on every poll/send by player 1
+-- updated_at continues to auto-update on any row change.
+
+ALTER TABLE game_sessions
+    ADD COLUMN last_seen_one TIMESTAMP(3) NULL AFTER reconnects_two,
+    ADD COLUMN last_seen_two TIMESTAMP(3) NULL AFTER last_seen_one;
+
+-- Backfill: set last_seen_one to updated_at for active sessions
+UPDATE game_sessions
+SET last_seen_one = updated_at
+WHERE status <= 1;
+
+-- Backfill: set last_seen_two to updated_at for in-progress sessions
+UPDATE game_sessions
+SET last_seen_two = updated_at
+WHERE status = 1 AND user_two_id IS NOT NULL;

--- a/utils/encryption.js
+++ b/utils/encryption.js
@@ -1,0 +1,263 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ */
+
+const crypto = require("crypto")
+const fs = require("fs")
+
+// Handshake protocol constants
+const HANDSHAKE_SIGNATURE = 0xfac2
+const HANDSHAKE_VERSION = 0x02
+
+/**
+ * Loads all configured RSA private keys from file paths.
+ * Reads NAVAL_RSA_PRIVATE_KEY_PATH_0, _1, _2, ... from environment.
+ *
+ * @returns {Array<string>} Array of PEM-encoded private keys
+ */
+function loadPrivateKeys() {
+    const keys = []
+    for (let i = 0; ; i++) {
+        const path = process.env[`NAVAL_RSA_PRIVATE_KEY_PATH_${i}`]
+        if (!path) break
+        if (fs.existsSync(path)) {
+            keys.push(fs.readFileSync(path, "utf8"))
+        } else {
+            console.warn(`RSA private key file not found: ${path}`)
+        }
+    }
+    if (keys.length === 0) {
+        console.warn("No RSA private keys configured!")
+    }
+    return keys
+}
+
+/**
+ * Loads HMAC token signing secret from file.
+ * Reads NAVAL_TOKEN_SECRET_PATH from environment.
+ *
+ * @returns {Buffer} Secret key bytes
+ */
+function loadTokenSecret() {
+    const path = process.env.NAVAL_TOKEN_SECRET_PATH
+    if (!path) {
+        console.warn("NAVAL_TOKEN_SECRET_PATH not configured!")
+        return Buffer.alloc(32)
+    }
+    if (!fs.existsSync(path)) {
+        console.warn(`Token secret file not found: ${path}`)
+        return Buffer.alloc(32)
+    }
+    const base64 = fs.readFileSync(path, "utf8").trim()
+    return Buffer.from(base64, "base64")
+}
+
+// Load keys at module initialization
+const RSA_PRIVATE_KEYS = loadPrivateKeys()
+const TOKEN_SECRET = loadTokenSecret()
+
+/**
+ * Returns the number of configured private keys.
+ *
+ * @returns {number} Key count
+ */
+function getKeyCount() {
+    return RSA_PRIVATE_KEYS.length
+}
+
+/**
+ * Parses binary handshake request.
+ * Format: [2 byte sig][1 byte ver][1 byte keyIdx][2 byte len][RSA-encrypted data]
+ *
+ * @param {Buffer} body - Raw binary request
+ * @returns {{ keyIndex: number, encrypted: Buffer }}
+ * @throws {Error} If format is invalid
+ */
+function parseHandshakeRequest(body) {
+    if (!Buffer.isBuffer(body) || body.length < 6) {
+        throw new Error("Handshake too short")
+    }
+
+    const sig = (body[0] << 8) | body[1]
+    if (sig !== HANDSHAKE_SIGNATURE) {
+        throw new Error("Invalid handshake signature")
+    }
+
+    const version = body[2]
+    if (version !== HANDSHAKE_VERSION) {
+        throw new Error(`Unsupported handshake version: ${version}`)
+    }
+
+    const keyIndex = body[3]
+    const length = (body[4] << 8) | body[5]
+
+    if (body.length !== 6 + length) {
+        throw new Error("Handshake length mismatch")
+    }
+
+    const encrypted = body.slice(6)
+    return { keyIndex, encrypted }
+}
+
+/**
+ * Decrypts RSA-OAEP encrypted data (from handshake).
+ *
+ * @param {Buffer} encrypted - RSA ciphertext
+ * @param {number} keyIndex - Index of the private key to use
+ * @returns {Buffer} Decrypted plaintext (JSON string as bytes)
+ * @throws {Error} If key index is invalid or decryption fails
+ */
+function rsaDecrypt(encrypted, keyIndex = 0) {
+    if (keyIndex < 0 || keyIndex >= RSA_PRIVATE_KEYS.length) {
+        throw new Error(`Invalid key index: ${keyIndex}`)
+    }
+
+    return crypto.privateDecrypt(
+        {
+            key: RSA_PRIVATE_KEYS[keyIndex],
+            padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+            oaepHash: "sha256",
+        },
+        encrypted
+    )
+}
+
+/**
+ * Decrypts AES-256-GCM data.
+ * Java appends the 16-byte tag to ciphertext, so we split it.
+ *
+ * @param {Buffer} key - 32-byte AES key
+ * @param {Buffer} iv - 12-byte IV
+ * @param {Buffer} ciphertextWithTag - Ciphertext with 16-byte tag appended
+ * @returns {Buffer} Decrypted plaintext
+ */
+function aesGcmDecrypt(key, iv, ciphertextWithTag) {
+    const tag = ciphertextWithTag.slice(-16)
+    const ciphertext = ciphertextWithTag.slice(0, -16)
+
+    const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv)
+    decipher.setAuthTag(tag)
+
+    return Buffer.concat([decipher.update(ciphertext), decipher.final()])
+}
+
+/**
+ * Encrypts data with AES-256-GCM.
+ * Appends 16-byte tag to ciphertext (Java-compatible format).
+ *
+ * @param {Buffer} key - 32-byte AES key
+ * @param {Buffer} plaintext - Data to encrypt
+ * @returns {{ iv: Buffer, ciphertext: Buffer }} IV and ciphertext+tag
+ */
+function aesGcmEncrypt(key, plaintext) {
+    const iv = crypto.randomBytes(12)
+    const cipher = crypto.createCipheriv("aes-256-gcm", key, iv)
+
+    const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()])
+    const tag = cipher.getAuthTag()
+
+    return {
+        iv,
+        ciphertext: Buffer.concat([encrypted, tag]),
+    }
+}
+
+/**
+ * Generates a 32-byte binary device token.
+ * Token is associated with device (not user).
+ *
+ * Structure (32 bytes):
+ *   [20 bytes: random][4 bytes: expiry][8 bytes: HMAC]
+ *
+ * @param {number} expirySeconds - Token lifetime (default 4 hours)
+ * @returns {Buffer} 32-byte token
+ */
+function generateDeviceToken(expirySeconds = 4 * 60 * 60) {
+    const token = Buffer.alloc(32)
+
+    // Random prefix (20 bytes)
+    crypto.randomBytes(20).copy(token, 0)
+
+    // Expiry timestamp (4 bytes, big-endian)
+    const expiry = Math.floor(Date.now() / 1000) + expirySeconds
+    token.writeUInt32BE(expiry, 20)
+
+    // HMAC of first 24 bytes (8 bytes)
+    const hmac = crypto
+        .createHmac("sha256", TOKEN_SECRET)
+        .update(token.slice(0, 24))
+        .digest()
+        .slice(0, 8)
+    hmac.copy(token, 24)
+
+    return token
+}
+
+/**
+ * Validates a binary device token (no DB lookup needed).
+ *
+ * @param {Buffer} token - 32-byte binary token
+ * @returns {{ valid: boolean, expired?: boolean }}
+ */
+function validateDeviceToken(token) {
+    if (!Buffer.isBuffer(token) || token.length !== 32) {
+        return { valid: false }
+    }
+
+    // Verify HMAC
+    const expectedHmac = crypto
+        .createHmac("sha256", TOKEN_SECRET)
+        .update(token.slice(0, 24))
+        .digest()
+        .slice(0, 8)
+
+    if (!crypto.timingSafeEqual(token.slice(24, 32), expectedHmac)) {
+        return { valid: false }
+    }
+
+    // Check expiry
+    const expiry = token.readUInt32BE(20)
+    if (Date.now() / 1000 > expiry) {
+        return { valid: false, expired: true }
+    }
+
+    return { valid: true }
+}
+
+/**
+ * Converts binary token to base64 for JSON/DB storage.
+ *
+ * @param {Buffer} token - 32-byte binary token
+ * @returns {string} Base64-encoded token
+ */
+function tokenToBase64(token) {
+    return token.toString("base64")
+}
+
+/**
+ * Converts base64 token back to binary.
+ *
+ * @param {string} base64Token - Base64-encoded token
+ * @returns {Buffer} 32-byte binary token
+ */
+function tokenFromBase64(base64Token) {
+    return Buffer.from(base64Token, "base64")
+}
+
+module.exports = {
+    HANDSHAKE_SIGNATURE,
+    HANDSHAKE_VERSION,
+    loadPrivateKeys,
+    loadTokenSecret,
+    getKeyCount,
+    parseHandshakeRequest,
+    rsaDecrypt,
+    aesGcmDecrypt,
+    aesGcmEncrypt,
+    generateDeviceToken,
+    validateDeviceToken,
+    tokenToBase64,
+    tokenFromBase64,
+}

--- a/utils/encryption.test.js
+++ b/utils/encryption.test.js
@@ -1,0 +1,277 @@
+/**
+ * Naval Clash - Multiplayer Battleship Game
+ * Copyright (c) 2026 NorthernCaptain
+ * All rights reserved.
+ */
+
+const crypto = require("crypto")
+const fs = require("fs")
+const path = require("path")
+
+// Generate a test RSA key pair for testing
+const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+})
+
+const privatePem = privateKey.export({ type: "pkcs1", format: "pem" })
+const publicDer = publicKey.export({ type: "spki", format: "der" })
+
+// Write test key to temp file and set env vars before requiring module
+const tmpDir = path.join(__dirname, "../tmp/test-keys")
+fs.mkdirSync(tmpDir, { recursive: true })
+fs.writeFileSync(path.join(tmpDir, "test_private_v1.pem"), privatePem)
+
+const tokenSecret = crypto.randomBytes(32).toString("base64")
+fs.writeFileSync(path.join(tmpDir, "test_token_secret.txt"), tokenSecret)
+
+process.env.NAVAL_RSA_PRIVATE_KEY_PATH_0 = path.join(
+    tmpDir,
+    "test_private_v1.pem"
+)
+process.env.NAVAL_TOKEN_SECRET_PATH = path.join(tmpDir, "test_token_secret.txt")
+
+const {
+    HANDSHAKE_SIGNATURE,
+    HANDSHAKE_VERSION,
+    getKeyCount,
+    parseHandshakeRequest,
+    rsaDecrypt,
+    aesGcmDecrypt,
+    aesGcmEncrypt,
+    generateDeviceToken,
+    validateDeviceToken,
+    tokenToBase64,
+    tokenFromBase64,
+} = require("./encryption")
+
+afterAll(() => {
+    // Clean up temp files
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+    delete process.env.NAVAL_RSA_PRIVATE_KEY_PATH_0
+    delete process.env.NAVAL_TOKEN_SECRET_PATH
+})
+
+describe("utils/encryption", () => {
+    describe("getKeyCount", () => {
+        it("should return 1 configured key", () => {
+            expect(getKeyCount()).toBe(1)
+        })
+    })
+
+    describe("parseHandshakeRequest", () => {
+        it("should parse valid handshake binary", () => {
+            const encrypted = Buffer.from("test-encrypted-data")
+            const header = Buffer.alloc(6)
+            header.writeUInt16BE(HANDSHAKE_SIGNATURE, 0)
+            header.writeUInt8(HANDSHAKE_VERSION, 2)
+            header.writeUInt8(0, 3) // key index
+            header.writeUInt16BE(encrypted.length, 4)
+
+            const body = Buffer.concat([header, encrypted])
+            const result = parseHandshakeRequest(body)
+
+            expect(result.keyIndex).toBe(0)
+            expect(result.encrypted).toEqual(encrypted)
+        })
+
+        it("should reject body too short", () => {
+            expect(() => parseHandshakeRequest(Buffer.alloc(5))).toThrow(
+                "Handshake too short"
+            )
+        })
+
+        it("should reject non-buffer input", () => {
+            expect(() => parseHandshakeRequest("not-a-buffer")).toThrow(
+                "Handshake too short"
+            )
+        })
+
+        it("should reject invalid signature", () => {
+            const body = Buffer.alloc(10)
+            body.writeUInt16BE(0x1234, 0) // wrong signature
+            expect(() => parseHandshakeRequest(body)).toThrow(
+                "Invalid handshake signature"
+            )
+        })
+
+        it("should reject unsupported version", () => {
+            const body = Buffer.alloc(10)
+            body.writeUInt16BE(HANDSHAKE_SIGNATURE, 0)
+            body.writeUInt8(0x99, 2) // wrong version
+            expect(() => parseHandshakeRequest(body)).toThrow(
+                "Unsupported handshake version"
+            )
+        })
+
+        it("should reject length mismatch", () => {
+            const header = Buffer.alloc(6)
+            header.writeUInt16BE(HANDSHAKE_SIGNATURE, 0)
+            header.writeUInt8(HANDSHAKE_VERSION, 2)
+            header.writeUInt8(0, 3)
+            header.writeUInt16BE(100, 4) // claims 100 bytes
+
+            const body = Buffer.concat([header, Buffer.alloc(50)]) // only 50
+            expect(() => parseHandshakeRequest(body)).toThrow(
+                "Handshake length mismatch"
+            )
+        })
+    })
+
+    describe("rsaDecrypt", () => {
+        it("should decrypt RSA-OAEP encrypted data", () => {
+            const plaintext = Buffer.from('{"key":"test","uuid":"abc"}')
+            const encrypted = crypto.publicEncrypt(
+                {
+                    key: publicKey,
+                    padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+                    oaepHash: "sha256",
+                },
+                plaintext
+            )
+
+            const result = rsaDecrypt(encrypted, 0)
+            expect(result.toString("utf8")).toBe(plaintext.toString("utf8"))
+        })
+
+        it("should reject invalid key index", () => {
+            expect(() => rsaDecrypt(Buffer.alloc(256), 99)).toThrow(
+                "Invalid key index"
+            )
+        })
+
+        it("should reject negative key index", () => {
+            expect(() => rsaDecrypt(Buffer.alloc(256), -1)).toThrow(
+                "Invalid key index"
+            )
+        })
+    })
+
+    describe("AES-GCM roundtrip", () => {
+        it("should encrypt and decrypt correctly", () => {
+            const key = crypto.randomBytes(32)
+            const plaintext = Buffer.from('{"type":"connect","player":"Test"}')
+
+            const { iv, ciphertext } = aesGcmEncrypt(key, plaintext)
+
+            expect(iv.length).toBe(12)
+            expect(ciphertext.length).toBe(plaintext.length + 16) // +16 for tag
+
+            const decrypted = aesGcmDecrypt(key, iv, ciphertext)
+            expect(decrypted.toString("utf8")).toBe(plaintext.toString("utf8"))
+        })
+
+        it("should fail with wrong key", () => {
+            const key = crypto.randomBytes(32)
+            const wrongKey = crypto.randomBytes(32)
+            const plaintext = Buffer.from("test data")
+
+            const { iv, ciphertext } = aesGcmEncrypt(key, plaintext)
+
+            expect(() => aesGcmDecrypt(wrongKey, iv, ciphertext)).toThrow()
+        })
+
+        it("should fail with tampered ciphertext", () => {
+            const key = crypto.randomBytes(32)
+            const plaintext = Buffer.from("test data")
+
+            const { iv, ciphertext } = aesGcmEncrypt(key, plaintext)
+
+            // Tamper with ciphertext
+            ciphertext[0] ^= 0xff
+
+            expect(() => aesGcmDecrypt(key, iv, ciphertext)).toThrow()
+        })
+    })
+
+    describe("device tokens", () => {
+        it("should generate valid 32-byte token", () => {
+            const token = generateDeviceToken()
+            expect(token.length).toBe(32)
+        })
+
+        it("should validate freshly generated token", () => {
+            const token = generateDeviceToken()
+            const result = validateDeviceToken(token)
+            expect(result.valid).toBe(true)
+        })
+
+        it("should reject non-buffer input", () => {
+            const result = validateDeviceToken("not-a-buffer")
+            expect(result.valid).toBe(false)
+        })
+
+        it("should reject wrong length buffer", () => {
+            const result = validateDeviceToken(Buffer.alloc(16))
+            expect(result.valid).toBe(false)
+        })
+
+        it("should reject tampered token", () => {
+            const token = generateDeviceToken()
+            token[0] ^= 0xff // tamper with random prefix
+            const result = validateDeviceToken(token)
+            expect(result.valid).toBe(false)
+        })
+
+        it("should reject expired token", () => {
+            const token = generateDeviceToken(-1) // already expired
+            const result = validateDeviceToken(token)
+            expect(result.valid).toBe(false)
+            expect(result.expired).toBe(true)
+        })
+
+        it("should roundtrip through base64", () => {
+            const token = generateDeviceToken()
+            const base64 = tokenToBase64(token)
+            const restored = tokenFromBase64(base64)
+
+            expect(restored).toEqual(token)
+            expect(base64.length).toBe(44)
+        })
+    })
+
+    describe("full handshake flow", () => {
+        it("should parse, decrypt, and validate a complete handshake", () => {
+            const aesKey = crypto.randomBytes(32)
+            const payload = JSON.stringify({
+                key: aesKey.toString("base64"),
+                uuid: "test-device-uuid",
+                uuuid: "test-user-uuid",
+                v: 26,
+                p: "android",
+            })
+
+            // RSA encrypt the payload
+            const encrypted = crypto.publicEncrypt(
+                {
+                    key: publicKey,
+                    padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+                    oaepHash: "sha256",
+                },
+                Buffer.from(payload, "utf8")
+            )
+
+            // Build binary handshake
+            const header = Buffer.alloc(6)
+            header.writeUInt16BE(HANDSHAKE_SIGNATURE, 0)
+            header.writeUInt8(HANDSHAKE_VERSION, 2)
+            header.writeUInt8(0, 3)
+            header.writeUInt16BE(encrypted.length, 4)
+            const body = Buffer.concat([header, encrypted])
+
+            // Parse and decrypt
+            const { keyIndex, encrypted: enc } = parseHandshakeRequest(body)
+            expect(keyIndex).toBe(0)
+
+            const decrypted = rsaDecrypt(enc, keyIndex)
+            const parsed = JSON.parse(decrypted.toString("utf8"))
+
+            expect(parsed.uuid).toBe("test-device-uuid")
+            expect(parsed.uuuid).toBe("test-user-uuid")
+            expect(parsed.v).toBe(26)
+            expect(parsed.p).toBe("android")
+
+            const restoredKey = Buffer.from(parsed.key, "base64")
+            expect(restoredKey).toEqual(aesKey)
+        })
+    })
+})

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -80,7 +80,9 @@ function logWithContext(level, ctx, message, ...args) {
 
     const prefix = `${formatTimestamp()} ${level.substring(0, 3)}`
     const context = formatContext(ctx)
-    const fullMessage = context ? `${prefix} ${context} ${message}` : `${prefix} ${message}`
+    const fullMessage = context
+        ? `${prefix} ${context} ${message}`
+        : `${prefix} ${message}`
 
     switch (level) {
         case "ERROR":
@@ -105,7 +107,8 @@ const logger = {
      * @param {string} message - Log message
      * @param {...any} args - Additional arguments
      */
-    debug: (ctx, message, ...args) => logWithContext("DEBUG", ctx, message, ...args),
+    debug: (ctx, message, ...args) =>
+        logWithContext("DEBUG", ctx, message, ...args),
 
     /**
      * Info level logging.
@@ -113,7 +116,8 @@ const logger = {
      * @param {string} message - Log message
      * @param {...any} args - Additional arguments
      */
-    info: (ctx, message, ...args) => logWithContext("INFO", ctx, message, ...args),
+    info: (ctx, message, ...args) =>
+        logWithContext("INFO", ctx, message, ...args),
 
     /**
      * Warning level logging.
@@ -121,7 +125,8 @@ const logger = {
      * @param {string} message - Log message
      * @param {...any} args - Additional arguments
      */
-    warn: (ctx, message, ...args) => logWithContext("WARN", ctx, message, ...args),
+    warn: (ctx, message, ...args) =>
+        logWithContext("WARN", ctx, message, ...args),
 
     /**
      * Error level logging.
@@ -129,7 +134,8 @@ const logger = {
      * @param {string} message - Log message
      * @param {...any} args - Additional arguments
      */
-    error: (ctx, message, ...args) => logWithContext("ERROR", ctx, message, ...args),
+    error: (ctx, message, ...args) =>
+        logWithContext("ERROR", ctx, message, ...args),
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add complete Naval Clash multiplayer battleship backend on Express.js with MySQL: matchmaking, game flow (connect/shoot/fldinfo/fin), message queue with long-polling, cluster IPC broker for cross-worker delivery, and snowflake-style session IDs
- Implement encrypted transport layer with RSA handshake for AES-256-GCM key exchange, binary request/response middleware, and device token authentication with LRU-cached key lookup
- Add social features (rivals, search, recent opponents, online users), leaderboard with topstars/deduplication, weapon tracking & shop economy (coins, purchases, inventory), profile export/import, personal rival matchmaking with rematch flow, and AI agent matchmaking restrictions
- Add infrastructure: Node.js cluster mode, hot SSL certificate reload, structured logging, session purge background job, training data collection for AI model, Prettier formatting, mysql2/promise migration, and 19 SQL migration scripts
- Include comprehensive Jest test suite across all services and DB modules

## Test plan

- [ ] Run `npm test` — all existing and new unit tests pass
- [ ] Deploy to staging and test full game flow: connect → matchmaking → setup → shooting → finish
- [ ] Verify encrypted transport handshake works end-to-end with mobile client
- [ ] Test personal rival matchmaking and rematch flow
- [ ] Verify stale session detection and purge under load
- [ ] Test cluster mode with multiple workers and cross-worker message delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)