### PR TITLE
Add CANCEL_SESSION IPC to immediately notify polling clients on session close

### DIFF
--- a/services/navalclash/clusterBroker.js
+++ b/services/navalclash/clusterBroker.js
@@ -109,6 +109,38 @@ function handleUnsubscribe(msg) {
 }
 
 /**
+ * Handles CANCEL_SESSION message - cancels the poll for a closed session.
+ * Sends SESSION_CLOSED to the worker holding the poll so it returns errcode 5.
+ *
+ * @param {Object} msg - Message with sessionId
+ * @returns {void}
+ */
+function handleCancelSession(msg) {
+    const { sessionId } = msg
+    const ctx = { sid: sessionId }
+
+    const poll = activePolls.get(sessionId)
+    if (poll) {
+        const worker = cluster.workers[poll.workerId]
+        if (worker) {
+            logger.debug(
+                { ...ctx, reqId: poll.requestId, workerId: poll.workerId },
+                "Cancelling poll for closed session"
+            )
+            worker.send({
+                nc: true,
+                type: "SESSION_CLOSED",
+                requestId: poll.requestId,
+            })
+        }
+        activePolls.delete(sessionId)
+        requestToSession.delete(poll.requestId)
+    } else {
+        logger.debug(ctx, "No active poll for closed session")
+    }
+}
+
+/**
  * Handles PUBLISH message - wakes the receiver's poll.
  * Computes receiver's session ID by flipping sender's last bit.
  *
@@ -175,6 +207,9 @@ function setupWorkerHandlers(worker) {
             case "PUBLISH":
                 handlePublish(msg)
                 break
+            case "CANCEL_SESSION":
+                handleCancelSession(msg)
+                break
         }
     })
 }
@@ -240,5 +275,6 @@ module.exports = {
     handleSubscribe,
     handleUnsubscribe,
     handlePublish,
+    handleCancelSession,
     getOpponentSessionId,
 }

--- a/services/navalclash/clusterBroker.test.js
+++ b/services/navalclash/clusterBroker.test.js
@@ -8,6 +8,7 @@ const {
     handleSubscribe,
     handleUnsubscribe,
     handlePublish,
+    handleCancelSession,
     getOpponentSessionId,
     getActivePollCount,
     clearAllPolls,
@@ -218,6 +219,54 @@ describe("services/navalclash/clusterBroker", () => {
             expect(mockWorker1.send).not.toHaveBeenCalledWith(
                 expect.objectContaining({ type: "WAKE" })
             )
+        })
+    })
+
+    describe("handleCancelSession", () => {
+        it("should send SESSION_CLOSED to worker holding the poll", () => {
+            const mockWorker = { id: 1, send: jest.fn() }
+            const cluster = require("cluster")
+            cluster.workers = { 1: mockWorker }
+
+            handleSubscribe(mockWorker, {
+                sessionId: "1000",
+                pollId: 1,
+                requestId: "req-1",
+            })
+
+            expect(getActivePollCount()).toBe(1)
+
+            handleCancelSession({ sessionId: "1000" })
+
+            expect(mockWorker.send).toHaveBeenCalledWith({
+                nc: true,
+                type: "SESSION_CLOSED",
+                requestId: "req-1",
+            })
+            expect(getActivePollCount()).toBe(0)
+        })
+
+        it("should not fail when no poll exists for session", () => {
+            expect(() => {
+                handleCancelSession({ sessionId: "9999" })
+            }).not.toThrow()
+        })
+
+        it("should handle missing worker gracefully", () => {
+            const mockWorker = { id: 1, send: jest.fn() }
+            const cluster = require("cluster")
+            cluster.workers = {} // Worker gone
+
+            handleSubscribe(mockWorker, {
+                sessionId: "1000",
+                pollId: 1,
+                requestId: "req-1",
+            })
+
+            expect(() => {
+                handleCancelSession({ sessionId: "1000" })
+            }).not.toThrow()
+            expect(getActivePollCount()).toBe(0)
         })
     })
 

--- a/services/navalclash/gameService.js
+++ b/services/navalclash/gameService.js
@@ -11,7 +11,7 @@ const {
     dbFinalizeTrainingGame,
     dbGetSessionUserId,
 } = require("../../db/navalclash")
-const { sendMessage } = require("./messageService")
+const { sendMessage, cancelPollForSession } = require("./messageService")
 const { logger } = require("../../utils/logger")
 const {
     validateWeaponPlacement,
@@ -889,6 +889,8 @@ async function handlePlayerLeft(req, res, session, msg, u, ctx) {
                     session.baseSessionId.toString(),
                 ]
             )
+            // Cancel pending poll so client gets errcode 5 immediately
+            cancelPollForSession(session.sessionId)
             return res.json({ type: "ok" })
         }
 

--- a/services/navalclash/gameService.test.js
+++ b/services/navalclash/gameService.test.js
@@ -57,6 +57,7 @@ const { trackShuffleUsage } = require("./weaponService")
 
 jest.mock("./messageService", () => ({
     sendMessage: jest.fn().mockResolvedValue(1),
+    cancelPollForSession: jest.fn(),
 }))
 
 jest.mock("./leaderboardService", () => ({

--- a/services/navalclash/messageService.js
+++ b/services/navalclash/messageService.js
@@ -160,6 +160,72 @@ function handleCancel(requestId) {
     pollData.res.json({ type: "empty" })
 }
 
+/**
+ * Handles SESSION_CLOSED message from master.
+ * Resolves the pending poll with errcode 5 so the client reconnects immediately.
+ *
+ * @param {string} requestId - Request ID
+ * @returns {void}
+ */
+function handleSessionClosed(requestId) {
+    const pollData = pendingPolls.get(requestId)
+    if (!pollData) return
+
+    if (pollData.responded) return
+    pollData.responded = true
+
+    logger.debug(
+        { sid: pollData.sessionId, reqId: requestId },
+        "SESSION_CLOSED received, returning errcode 5"
+    )
+
+    clearTimeout(pollData.timer)
+    pendingPolls.delete(requestId)
+
+    if (cluster.isWorker) {
+        process.send({
+            nc: true,
+            type: "UNSUBSCRIBE",
+            requestId,
+        })
+    }
+
+    pollData.res.json({
+        type: "error",
+        errcode: 5,
+        reason: "Session terminated",
+    })
+}
+
+/**
+ * Cancels any pending poll for the given session ID with errcode 5.
+ * In cluster mode, sends IPC to master to route to the correct worker.
+ * In non-cluster mode, resolves the local poll directly.
+ *
+ * @param {BigInt|string} sessionId - Session ID (with player bit)
+ * @returns {void}
+ */
+function cancelPollForSession(sessionId) {
+    const sidStr = sessionId.toString()
+
+    if (cluster.isWorker) {
+        process.send({
+            nc: true,
+            type: "CANCEL_SESSION",
+            sessionId: sidStr,
+        })
+        return
+    }
+
+    // Non-cluster: find and resolve locally
+    for (const [reqId, pollData] of pendingPolls) {
+        if (pollData.sessionId.toString() === sidStr) {
+            handleSessionClosed(reqId)
+            return
+        }
+    }
+}
+
 let workerHandlersSetup = false
 
 /**
@@ -180,6 +246,9 @@ function setupWorkerHandlers() {
                 break
             case "CANCEL":
                 handleCancel(msg.requestId)
+                break
+            case "SESSION_CLOSED":
+                handleSessionClosed(msg.requestId)
                 break
         }
     })
@@ -523,6 +592,7 @@ module.exports = {
     poll,
     send,
     sendMessage,
+    cancelPollForSession,
     getOpponentSessionId,
     fetchNextMessage,
     deleteAcknowledgedMessages,
@@ -531,5 +601,6 @@ module.exports = {
     // Exported for testing
     handleWake,
     handleCancel,
+    handleSessionClosed,
     checkDeadOpponent,
 }

--- a/services/navalclash/messageService.test.js
+++ b/services/navalclash/messageService.test.js
@@ -27,11 +27,13 @@ const {
     poll,
     send,
     sendMessage,
+    cancelPollForSession,
     getOpponentSessionId,
     fetchNextMessage,
     deleteAcknowledgedMessages,
     getPendingPollCount,
     clearPendingPolls,
+    handleSessionClosed,
     checkDeadOpponent,
 } = require("./messageService")
 
@@ -464,6 +466,91 @@ describe("services/navalclash/messageService", () => {
             // Just ensure it doesn't throw
             expect(() => clearPendingPolls()).not.toThrow()
             expect(getPendingPollCount()).toBe(0)
+        })
+    })
+
+    describe("handleSessionClosed", () => {
+        it("should resolve pending poll with errcode 5", async () => {
+            const mockRes = { json: jest.fn() }
+
+            // Set up a long poll (no messages, no dead opponent)
+            mockExecute.mockResolvedValueOnce([[]]) // fetchNextMessage - empty
+            mockDbGetOpponentLastSeen.mockResolvedValueOnce({ status: 0 })
+            mockExecute.mockResolvedValueOnce([[]]) // race check - empty
+
+            const req = {
+                body: { sid: "1000", pollId: 1 },
+                requestId: "req-close-1",
+            }
+            await poll(req, mockRes)
+
+            expect(mockRes.json).not.toHaveBeenCalled()
+            expect(getPendingPollCount()).toBe(1)
+
+            handleSessionClosed("req-close-1")
+
+            expect(mockRes.json).toHaveBeenCalledWith({
+                type: "error",
+                errcode: 5,
+                reason: "Session terminated",
+            })
+            expect(getPendingPollCount()).toBe(0)
+        })
+
+        it("should not fail when poll does not exist", () => {
+            expect(() =>
+                handleSessionClosed("non-existent")
+            ).not.toThrow()
+        })
+
+        it("should not respond twice if already responded", async () => {
+            const mockRes = { json: jest.fn() }
+
+            mockExecute.mockResolvedValueOnce([[]]) // fetchNextMessage
+            mockDbGetOpponentLastSeen.mockResolvedValueOnce({ status: 0 })
+            mockExecute.mockResolvedValueOnce([[]]) // race check
+
+            const req = {
+                body: { sid: "1000", pollId: 1 },
+                requestId: "req-close-2",
+            }
+            await poll(req, mockRes)
+
+            handleSessionClosed("req-close-2")
+            handleSessionClosed("req-close-2")
+
+            expect(mockRes.json).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe("cancelPollForSession", () => {
+        it("should resolve local poll with errcode 5 in non-cluster mode", async () => {
+            const mockRes = { json: jest.fn() }
+
+            mockExecute.mockResolvedValueOnce([[]]) // fetchNextMessage
+            mockDbGetOpponentLastSeen.mockResolvedValueOnce({ status: 0 })
+            mockExecute.mockResolvedValueOnce([[]]) // race check
+
+            const req = {
+                body: { sid: "1000", pollId: 1 },
+                requestId: "req-cancel-1",
+            }
+            await poll(req, mockRes)
+
+            expect(getPendingPollCount()).toBe(1)
+
+            cancelPollForSession(1000n)
+
+            expect(mockRes.json).toHaveBeenCalledWith({
+                type: "error",
+                errcode: 5,
+                reason: "Session terminated",
+            })
+            expect(getPendingPollCount()).toBe(0)
+        })
+
+        it("should not fail when no poll exists for session", () => {
+            expect(() => cancelPollForSession(9999n)).not.toThrow()
         })
     })
 })


### PR DESCRIPTION
## Summary
- Add `CANCEL_SESSION` IPC message type so that when a player leaves a session, the opponent's pending poll is immediately resolved with errcode 5 instead of waiting for the poll timeout
- Implement `handleCancelSession` in clusterBroker and `handleSessionClosed`/`cancelPollForSession` in messageService
- Wire up the cancel in `handlePlayerLeft` in gameService

## Test plan
- [ ] Verify that when player A leaves mid-game, player B's polling `/receive` immediately returns `{ type: "error", errcode: 5 }` 
- [ ] Verify normal poll flow still works (subscribe/publish/unsubscribe)
- [ ] Verify non-cluster (single-process) mode handles cancel correctly
- [ ] Run `npm test` to confirm existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)