### PR TITLE
Add ban system, lang/version fields, and CANCEL_SESSION IPC

### DIFF
--- a/db/navalclash/leaderboard.js
+++ b/db/navalclash/leaderboard.js
@@ -25,10 +25,10 @@ async function dbGetTopScores(gameVariant, limitPerType = 50) {
         // Use query() instead of execute() to avoid prepared statement issues with LIMIT
         // Exclude banned users (isbanned = 1)
         const [androidRows] = await pool.query(
-            `SELECT ts.*, u.name, u.face, u.uuid,
-                    o.name AS opponent_name, o.face AS opponent_face
+            `SELECT ts.*, u.name, u.face, u.uuid, u.lang, u.version AS user_version,
+                    o.name AS opponent_name, o.face AS opponent_face, o.version AS opponent_version
              FROM topscores ts
-             JOIN users u ON u.id = ts.user_id AND u.isbanned = 0
+             JOIN users u ON u.id = ts.user_id AND (u.isbanned & 9) = 0
              LEFT JOIN users o ON o.id = ts.opponent_id
              INNER JOIN (
                  SELECT user_id, MAX(score) as max_score
@@ -45,10 +45,10 @@ async function dbGetTopScores(gameVariant, limitPerType = 50) {
         // Fetch top scores vs Human (game_type IN (2,3,4) - bt, web, passplay)
         // Exclude banned users (isbanned = 1)
         const [humanRows] = await pool.query(
-            `SELECT ts.*, u.name, u.face, u.uuid,
-                    o.name AS opponent_name, o.face AS opponent_face
+            `SELECT ts.*, u.name, u.face, u.uuid, u.lang, u.version AS user_version,
+                    o.name AS opponent_name, o.face AS opponent_face, o.version AS opponent_version
              FROM topscores ts
-             JOIN users u ON u.id = ts.user_id AND u.isbanned = 0
+             JOIN users u ON u.id = ts.user_id AND (u.isbanned & 9) = 0
              LEFT JOIN users o ON o.id = ts.opponent_id
              INNER JOIN (
                  SELECT user_id, MAX(score) as max_score
@@ -89,10 +89,10 @@ async function dbGetTopScoresByType(gameVariant, gameType, limit) {
         // Note: Use query() instead of execute() to avoid prepared statement issues with LIMIT
         // Exclude banned users (isbanned = 1)
         const [rows] = await pool.query(
-            `SELECT ts.*, u.name, u.face, u.uuid,
-                    o.name AS opponent_name, o.face AS opponent_face
+            `SELECT ts.*, u.name, u.face, u.uuid, u.lang, u.version AS user_version,
+                    o.name AS opponent_name, o.face AS opponent_face, o.version AS opponent_version
              FROM topscores ts
-             JOIN users u ON u.id = ts.user_id AND u.isbanned = 0
+             JOIN users u ON u.id = ts.user_id AND (u.isbanned & 9) = 0
              LEFT JOIN users o ON o.id = ts.opponent_id
              INNER JOIN (
                  SELECT user_id, MAX(score) as max_score
@@ -263,14 +263,14 @@ async function dbGetTopStars(gameVariant, limit) {
         // Note: Use query() instead of execute() to avoid prepared statement issues with LIMIT
         // Exclude banned users (isbanned = 1)
         const [rows] = await pool.query(
-            `SELECT id, name, uuid, \`rank\`, stars, face,
+            `SELECT id, name, uuid, \`rank\`, stars, face, lang,
                     games, gameswon, version,
                     games_android, games_bluetooth, games_web, games_passplay,
                     wins_android, wins_bluetooth, wins_web, wins_passplay
              FROM users
              WHERE stars > 0
                AND last_game_variant = ?
-               AND isbanned = 0
+               AND (isbanned & 9) = 0
              ORDER BY stars DESC, gameswon DESC
              LIMIT ?`,
             [gameVariant, Number(limit)]

--- a/db/navalclash/leaderboard.js
+++ b/db/navalclash/leaderboard.js
@@ -23,7 +23,7 @@ async function dbGetTopScores(gameVariant, limitPerType = 50) {
     try {
         // Fetch top scores vs Android (game_type = 1)
         // Use query() instead of execute() to avoid prepared statement issues with LIMIT
-        // Exclude banned users (isbanned = 1)
+        // Exclude users banned from game or scores (BAN.GAME | BAN.SCORES = 9)
         const [androidRows] = await pool.query(
             `SELECT ts.*, u.name, u.face, u.uuid, u.lang, u.version AS user_version,
                     o.name AS opponent_name, o.face AS opponent_face, o.version AS opponent_version
@@ -43,7 +43,7 @@ async function dbGetTopScores(gameVariant, limitPerType = 50) {
         )
 
         // Fetch top scores vs Human (game_type IN (2,3,4) - bt, web, passplay)
-        // Exclude banned users (isbanned = 1)
+        // Exclude users banned from game or scores (BAN.GAME | BAN.SCORES = 9)
         const [humanRows] = await pool.query(
             `SELECT ts.*, u.name, u.face, u.uuid, u.lang, u.version AS user_version,
                     o.name AS opponent_name, o.face AS opponent_face, o.version AS opponent_version
@@ -87,7 +87,7 @@ async function dbGetTopScores(gameVariant, limitPerType = 50) {
 async function dbGetTopScoresByType(gameVariant, gameType, limit) {
     try {
         // Note: Use query() instead of execute() to avoid prepared statement issues with LIMIT
-        // Exclude banned users (isbanned = 1)
+        // Exclude users banned from game or scores (BAN.GAME | BAN.SCORES = 9)
         const [rows] = await pool.query(
             `SELECT ts.*, u.name, u.face, u.uuid, u.lang, u.version AS user_version,
                     o.name AS opponent_name, o.face AS opponent_face, o.version AS opponent_version
@@ -261,7 +261,7 @@ async function dbGetUserLeaderboardRank(userId, gameVariant) {
 async function dbGetTopStars(gameVariant, limit) {
     try {
         // Note: Use query() instead of execute() to avoid prepared statement issues with LIMIT
-        // Exclude banned users (isbanned = 1)
+        // Exclude users banned from game or scores (BAN.GAME | BAN.SCORES = 9)
         const [rows] = await pool.query(
             `SELECT id, name, uuid, \`rank\`, stars, face, lang,
                     games, gameswon, version,

--- a/db/navalclash/leaderboard.test.js
+++ b/db/navalclash/leaderboard.test.js
@@ -84,6 +84,20 @@ describe("db/navalclash/leaderboard", () => {
 
             expect(result).toEqual([])
         })
+
+        it("should use bitmask filter to exclude game and scores bans", async () => {
+            mockQuery
+                .mockResolvedValueOnce([[]]) // Android query
+                .mockResolvedValueOnce([[]]) // Human query
+
+            await dbGetTopScores(1, 50)
+
+            // Both queries should use bitmask filter
+            expect(mockQuery).toHaveBeenCalledWith(
+                expect.stringContaining("(u.isbanned & 9) = 0"),
+                expect.anything()
+            )
+        })
     })
 
     describe("dbGetTopScoresByType", () => {
@@ -99,6 +113,19 @@ describe("db/navalclash/leaderboard", () => {
             expect(mockQuery).toHaveBeenCalledWith(
                 expect.stringContaining("game_type = ?"),
                 [1, 3, 1, 3, 10]
+            )
+        })
+    })
+
+    describe("dbGetTopScoresByType - bitmask filter", () => {
+        it("should use bitmask filter to exclude game and scores bans", async () => {
+            mockQuery.mockResolvedValue([[]])
+
+            await dbGetTopScoresByType(1, 3, 10)
+
+            expect(mockQuery).toHaveBeenCalledWith(
+                expect.stringContaining("(u.isbanned & 9) = 0"),
+                expect.anything()
             )
         })
     })
@@ -288,6 +315,17 @@ describe("db/navalclash/leaderboard", () => {
             expect(result).toEqual(mockUsers)
             expect(mockQuery).toHaveBeenCalledWith(
                 expect.stringContaining("ORDER BY stars DESC"),
+                [1, 50]
+            )
+        })
+
+        it("should use bitmask filter to exclude game and scores bans", async () => {
+            mockQuery.mockResolvedValue([[]])
+
+            await dbGetTopStars(1, 50)
+
+            expect(mockQuery).toHaveBeenCalledWith(
+                expect.stringContaining("(isbanned & 9) = 0"),
                 [1, 50]
             )
         })

--- a/services/navalclash/connectService.js
+++ b/services/navalclash/connectService.js
@@ -11,7 +11,7 @@ const {
 } = require("../../db/navalclash")
 const { logger } = require("../../utils/logger")
 const { getMinVersion, isMaintenanceMode } = require("./setupService")
-const { MSG, SESSION_STATUS, VERSION } = require("./constants")
+const { MSG, SESSION_STATUS, VERSION, BAN } = require("./constants")
 
 /**
  * Checks if a version indicates an AI agent.
@@ -156,10 +156,11 @@ async function getOrCreateUser(conn, body) {
             `UPDATE users SET
                 logins = logins + 1,
                 version = ?,
+                lang = COALESCE(?, lang),
                 last_game_variant = ?,
                 updated_at = NOW()
              WHERE id = ?`,
-            [body.v || 0, body.var || 1, user.id]
+            [body.v || 0, body.u?.l || null, body.var || 1, user.id]
         )
         user.logins++
         return user
@@ -169,7 +170,7 @@ async function getOrCreateUser(conn, body) {
     const [result] = await conn.execute(
         `INSERT INTO users (name, uuid, version, lang, last_game_variant, logins)
          VALUES (?, ?, ?, ?, ?, 1)`,
-        [body.player, body.uuuid, body.v || 0, body.lang || null, body.var || 1]
+        [body.player, body.uuuid, body.v || 0, body.u?.l || null, body.var || 1]
     )
 
     const userId = result.insertId
@@ -759,7 +760,7 @@ async function connect(req, res) {
             await getOrCreateDevice(conn, user.id, body)
         }
 
-        if (user.isbanned) {
+        if (user.isbanned & BAN.GAME) {
             logger.warn(ctx, "User is banned, refusing connection")
             await conn.commit()
             // Return banned response with InfoMessage format expected by client

--- a/services/navalclash/connectService.test.js
+++ b/services/navalclash/connectService.test.js
@@ -235,6 +235,24 @@ describe("services/navalclash/connectService", () => {
             )
         })
 
+        it("should allow scores-banned user to connect (isbanned=8)", async () => {
+            const req = {
+                body: { type: "connect", player: "ScoresBanned", uuuid: "uuid" },
+            }
+
+            mockConnection.execute
+                .mockResolvedValueOnce([]) // SET TRANSACTION ISOLATION LEVEL
+                .mockResolvedValueOnce([[{ id: 1, isbanned: 8 }]]) // find user (scores ban only)
+                .mockResolvedValueOnce([{ affectedRows: 1 }]) // update login
+
+            await connect(req, mockRes)
+
+            // Should NOT return banned — scores ban does not block connect
+            expect(mockRes.json).not.toHaveBeenCalledWith(
+                expect.objectContaining({ type: "banned" })
+            )
+        })
+
         it("should reject user with combined game+chat ban (isbanned=17)", async () => {
             const req = {
                 body: {

--- a/services/navalclash/connectService.test.js
+++ b/services/navalclash/connectService.test.js
@@ -217,6 +217,53 @@ describe("services/navalclash/connectService", () => {
             expect(mockConnection.commit).toHaveBeenCalled()
         })
 
+        it("should allow chat-banned user to connect (isbanned=16)", async () => {
+            const req = {
+                body: { type: "connect", player: "ChatBanned", uuuid: "uuid" },
+            }
+
+            mockConnection.execute
+                .mockResolvedValueOnce([]) // SET TRANSACTION ISOLATION LEVEL
+                .mockResolvedValueOnce([[{ id: 1, isbanned: 16 }]]) // find user (chat ban only)
+                .mockResolvedValueOnce([{ affectedRows: 1 }]) // update login
+
+            await connect(req, mockRes)
+
+            // Should NOT return banned — chat ban does not block connect
+            expect(mockRes.json).not.toHaveBeenCalledWith(
+                expect.objectContaining({ type: "banned" })
+            )
+        })
+
+        it("should reject user with combined game+chat ban (isbanned=17)", async () => {
+            const req = {
+                body: {
+                    type: "connect",
+                    player: "DoubleBanned",
+                    uuuid: "uuid",
+                },
+            }
+
+            mockConnection.execute
+                .mockResolvedValueOnce([]) // SET TRANSACTION ISOLATION LEVEL
+                .mockResolvedValueOnce([[{ id: 1, isbanned: 17 }]]) // game + chat ban
+                .mockResolvedValueOnce([{ affectedRows: 1 }]) // update login
+
+            await connect(req, mockRes)
+
+            expect(mockRes.json).toHaveBeenCalledWith({
+                type: "banned",
+                msg: {
+                    type: "msg",
+                    m: 9,
+                    p: [],
+                    c: false,
+                },
+                errcode: 1,
+            })
+            expect(mockConnection.commit).toHaveBeenCalled()
+        })
+
         it("should return maintenance when in maintenance mode", async () => {
             const req = {
                 body: { type: "connect", player: "Test", uuuid: "uuid" },

--- a/services/navalclash/constants.js
+++ b/services/navalclash/constants.js
@@ -48,6 +48,17 @@ const MSG = {
 }
 
 // =============================================================================
+// BAN TYPE CONSTANTS (bitmask)
+// Stored in users.isbanned (SMALLINT UNSIGNED)
+// =============================================================================
+
+const BAN = {
+    GAME: 1, // Bit 0: cannot connect/play
+    SCORES: 8, // Bit 3: excluded from leaderboards
+    CHAT: 16, // Bit 4: cannot send chat messages (silent drop)
+}
+
+// =============================================================================
 // SESSION STATUS CONSTANTS
 // Game session lifecycle states stored in game_sessions.status
 // =============================================================================
@@ -273,6 +284,9 @@ const FIELD = {
 // =============================================================================
 
 module.exports = {
+    // Ban types
+    BAN,
+
     // Message constants
     MSG,
 

--- a/services/navalclash/constants.js
+++ b/services/navalclash/constants.js
@@ -52,10 +52,12 @@ const MSG = {
 // Stored in users.isbanned (SMALLINT UNSIGNED)
 // =============================================================================
 
+// Bits 1-2 are reserved for legacy compatibility (old server used values up to 4096)
 const BAN = {
     GAME: 1, // Bit 0: cannot connect/play
     SCORES: 8, // Bit 3: excluded from leaderboards
     CHAT: 16, // Bit 4: cannot send chat messages (silent drop)
+    GAME_OR_SCORES: 1 | 8, // Combined mask for leaderboard exclusion (= 9)
 }
 
 // =============================================================================

--- a/services/navalclash/gameService.js
+++ b/services/navalclash/gameService.js
@@ -1026,7 +1026,7 @@ async function chat(req, res) {
     )
     if (userId) {
         const user = await dbFindUserById(userId)
-        if (user && user.isbanned & BAN.CHAT) {
+        if (user && (user.isbanned & BAN.CHAT)) {
             logger.debug(ctx, "Chat message dropped (user chat-banned)")
             return res.json({ type: "ok" })
         }

--- a/services/navalclash/gameService.js
+++ b/services/navalclash/gameService.js
@@ -10,6 +10,7 @@ const {
     dbGetTrainingShotCount,
     dbFinalizeTrainingGame,
     dbGetSessionUserId,
+    dbFindUserById,
 } = require("../../db/navalclash")
 const { sendMessage, cancelPollForSession } = require("./messageService")
 const { logger } = require("../../utils/logger")
@@ -30,6 +31,7 @@ const {
     MAX_RANK_DELTA,
     VERSION,
     FIELD,
+    BAN,
 } = require("./constants")
 
 // Rank thresholds (stars required for each rank - from UserBaseData.java)
@@ -1016,6 +1018,19 @@ async function chat(req, res) {
 
     const session = validateSession(sid, res, ctx)
     if (!session) return
+
+    // Check chat ban — silently drop message (matching old server behavior)
+    const userId = await dbGetSessionUserId(
+        session.baseSessionId,
+        session.player
+    )
+    if (userId) {
+        const user = await dbFindUserById(userId)
+        if (user && user.isbanned & BAN.CHAT) {
+            logger.debug(ctx, "Chat message dropped (user chat-banned)")
+            return res.json({ type: "ok" })
+        }
+    }
 
     return sendAndRespond(res, session.sessionId, "chat", { msg, u }, ctx)
 }

--- a/services/navalclash/gameService.test.js
+++ b/services/navalclash/gameService.test.js
@@ -33,6 +33,7 @@ jest.mock("../../db/navalclash", () => ({
     dbGetTrainingShotCount: jest.fn().mockResolvedValue(0),
     dbFinalizeTrainingGame: jest.fn().mockResolvedValue(true),
     dbGetSessionUserId: jest.fn().mockResolvedValue(10),
+    dbFindUserById: jest.fn().mockResolvedValue({ id: 10, isbanned: 0 }),
 }))
 
 jest.mock("./weaponService", () => ({
@@ -51,6 +52,7 @@ const {
     dbGetTrainingShotCount,
     dbFinalizeTrainingGame,
     dbGetSessionUserId,
+    dbFindUserById,
 } = require("../../db/navalclash")
 
 const { trackShuffleUsage } = require("./weaponService")
@@ -748,6 +750,13 @@ describe("services/navalclash/gameService", () => {
     describe("chat", () => {
         const mockRes = { json: jest.fn() }
 
+        beforeEach(() => {
+            mockRes.json.mockClear()
+            sendMessage.mockClear()
+            dbGetSessionUserId.mockResolvedValue(10)
+            dbFindUserById.mockResolvedValue({ id: 10, isbanned: 0 })
+        })
+
         it("should send chat message", async () => {
             const req = {
                 requestId: "test",
@@ -759,6 +768,49 @@ describe("services/navalclash/gameService", () => {
             expect(sendMessage).toHaveBeenCalledWith(1000n, "chat", {
                 msg: "GG",
             })
+        })
+
+        it("should silently drop chat for chat-banned user (isbanned=16)", async () => {
+            dbFindUserById.mockResolvedValue({ id: 10, isbanned: 16 })
+
+            const req = {
+                requestId: "test",
+                body: { sid: "1000", msg: "spam" },
+            }
+
+            await chat(req, mockRes)
+
+            expect(sendMessage).not.toHaveBeenCalled()
+            expect(mockRes.json).toHaveBeenCalledWith({ type: "ok" })
+        })
+
+        it("should allow chat for scores-banned user (isbanned=8)", async () => {
+            dbFindUserById.mockResolvedValue({ id: 10, isbanned: 8 })
+
+            const req = {
+                requestId: "test",
+                body: { sid: "1000", msg: "hello" },
+            }
+
+            await chat(req, mockRes)
+
+            expect(sendMessage).toHaveBeenCalledWith(1000n, "chat", {
+                msg: "hello",
+            })
+        })
+
+        it("should silently drop chat for combined chat+scores ban (isbanned=24)", async () => {
+            dbFindUserById.mockResolvedValue({ id: 10, isbanned: 24 })
+
+            const req = {
+                requestId: "test",
+                body: { sid: "1000", msg: "hi" },
+            }
+
+            await chat(req, mockRes)
+
+            expect(sendMessage).not.toHaveBeenCalled()
+            expect(mockRes.json).toHaveBeenCalledWith({ type: "ok" })
         })
     })
 

--- a/services/navalclash/leaderboardService.js
+++ b/services/navalclash/leaderboardService.js
@@ -33,6 +33,8 @@ function serializeScore(row) {
         time: row.time_spent_ms || 30001, // Fallback to minimum valid time if missing
         gtype: dbGtypeToClient(row.game_type), // Convert DB (1-4) to client (0-3)
         ct: row.created_at ? new Date(row.created_at).getTime() : Date.now(),
+        uv: row.user_version || 0,
+        ov: row.opponent_version || 0,
         // Winner player info
         u: {
             nam: row.name,
@@ -40,6 +42,7 @@ function serializeScore(row) {
             rk: row.user_rank || 0,
             fc: row.face || 0,
             id: row.uuid || "",
+            l: row.lang || "--",
         },
     }
 
@@ -71,12 +74,14 @@ function serializeStarEntry(row) {
         time: 30001, // Minimum valid time (client requires >= 30000ms)
         gtype: 3, // Default to web
         ct: Date.now(),
+        uv: row.version || 0,
         u: {
             nam: row.name,
             i: row.id,
             rk: row.rank || 0,
             fc: row.face || 0,
             id: row.uuid || "",
+            l: row.lang || "--",
             st: row.stars || 0,
             pld: row.games || 0,
             won: row.gameswon || 0,

--- a/services/navalclash/leaderboardService.test.js
+++ b/services/navalclash/leaderboardService.test.js
@@ -61,6 +61,8 @@ describe("services/navalclash/leaderboardService", () => {
                 name: "Winner",
                 face: 5,
                 uuid: "winner-uuid",
+                lang: "en_US",
+                user_version: 2035,
                 score: 5500,
                 time_spent_ms: 60000,
                 user_rank: 5,
@@ -70,6 +72,7 @@ describe("services/navalclash/leaderboardService", () => {
                 opponent_name: "Loser",
                 opponent_face: 3,
                 opponent_rank: 4,
+                opponent_version: 2035,
             }
 
             const result = serializeScore(row)
@@ -80,12 +83,15 @@ describe("services/navalclash/leaderboardService", () => {
                 time: 60000,
                 gtype: 2, // DB game_type 3 (web) -> client gtype 2 (web)
                 ct: new Date("2026-01-15T10:30:00Z").getTime(),
+                uv: 2035,
+                ov: 2035,
                 u: {
                     nam: "Winner",
                     i: 123,
                     rk: 5,
                     fc: 5,
                     id: "winner-uuid",
+                    l: "en_US",
                 },
                 o: {
                     nam: "Loser",
@@ -121,9 +127,12 @@ describe("services/navalclash/leaderboardService", () => {
 
             const result = serializeScore(row)
 
+            expect(result.uv).toBe(0)
+            expect(result.ov).toBe(0)
             expect(result.u.fc).toBe(0)
             expect(result.u.rk).toBe(0)
             expect(result.u.id).toBe("")
+            expect(result.u.l).toBe("--")
         })
     })
 
@@ -133,6 +142,8 @@ describe("services/navalclash/leaderboardService", () => {
                 id: 123,
                 name: "StarPlayer",
                 uuid: "star-uuid",
+                lang: "ru_RU",
+                version: 2035,
                 rank: 7,
                 stars: 5000,
                 face: 3,
@@ -152,9 +163,11 @@ describe("services/navalclash/leaderboardService", () => {
 
             expect(result.type).toBe("Score")
             expect(result.score).toBe(5000)
+            expect(result.uv).toBe(2035)
             expect(result.u.nam).toBe("StarPlayer")
             expect(result.u.i).toBe(123)
             expect(result.u.rk).toBe(7)
+            expect(result.u.l).toBe("ru_RU")
             expect(result.u.st).toBe(5000)
             expect(result.u.pld).toBe(200)
             expect(result.u.won).toBe(150)
@@ -173,6 +186,8 @@ describe("services/navalclash/leaderboardService", () => {
             const result = serializeStarEntry(row)
 
             expect(result.score).toBe(0)
+            expect(result.uv).toBe(0)
+            expect(result.u.l).toBe("--")
             expect(result.u.st).toBe(0)
             expect(result.u.ga).toEqual([0, 0, 0, 0])
             expect(result.u.wa).toEqual([0, 0, 0, 0])

--- a/services/navalclash/profileService.js
+++ b/services/navalclash/profileService.js
@@ -16,6 +16,7 @@ const {
     dbGetUserWeaponArrays,
 } = require("../../db/navalclash")
 const { logger } = require("../../utils/logger")
+const { BAN } = require("./constants")
 
 /**
  * Generates a unique PIN for a user.
@@ -297,8 +298,8 @@ async function importProfile(req, res) {
 
         ctx.uid = user.id
 
-        // Check if user is banned
-        if (user.isbanned) {
+        // Check if user is banned from playing
+        if (user.isbanned & BAN.GAME) {
             logger.warn(ctx, "Import failed - user is banned")
             return res.json({ type: "uimpres" })
         }

--- a/services/navalclash/profileService.test.js
+++ b/services/navalclash/profileService.test.js
@@ -388,6 +388,23 @@ describe("profileService", () => {
             expect(mockRes.json).toHaveBeenCalledWith({ type: "uimpres" })
         })
 
+        it("should allow chat-banned user to import (isbanned=16)", async () => {
+            const chatBannedUser = {
+                id: 42,
+                name: "ChatBanned",
+                pin: 1234,
+                isbanned: 16,
+            }
+
+            mockReq = { body: { name: "ChatBanned", pin: "1234" } }
+            dbFindUserByNameAndPin.mockResolvedValue(chatBannedUser)
+
+            await importProfile(mockReq, mockRes)
+
+            // Chat ban should NOT block import (only game ban does)
+            expect(mockRes.json).not.toHaveBeenCalledWith({ type: "uimpres" })
+        })
+
         it("should return empty response on database error", async () => {
             mockReq = { body: { name: "TestPlayer", pin: "1234" } }
             dbFindUserByNameAndPin.mockRejectedValue(new Error("DB error"))

--- a/services/navalclash/socialService.js
+++ b/services/navalclash/socialService.js
@@ -8,7 +8,7 @@ const { pool, dbUpdateLocalStats } = require("../../db/navalclash")
 const { logger } = require("../../utils/logger")
 const { buildMdfMessage } = require("./gameService")
 const { sendMessage } = require("./messageService")
-const { MSG, LIST_TYPE, RIVAL_TYPE, USER_STATUS } = require("./constants")
+const { MSG, LIST_TYPE, RIVAL_TYPE, USER_STATUS, BAN } = require("./constants")
 
 /**
  * Serializes a rival object for API response.
@@ -683,7 +683,7 @@ async function userMarker(req, res) {
 
         // Check for pending personal game invitations
         // Only check if user is not already in a session (no sid provided)
-        if (!sid && !user.isbanned) {
+        if (!sid && !(user.isbanned & BAN.GAME)) {
             const invitation = await findPendingInvitation(user.id, gameVariant)
             if (invitation) {
                 logger.info(
@@ -819,8 +819,8 @@ async function userAnswer(req, res) {
 
     ctx.uid = user.id
 
-    // Check if user is banned
-    if (user.isbanned) {
+    // Check if user is banned from playing
+    if (user.isbanned & BAN.GAME) {
         logger.warn(ctx, "User is banned, refusing answer")
         return res.json({
             type: "banned",

--- a/services/navalclash/socialService.test.js
+++ b/services/navalclash/socialService.test.js
@@ -695,6 +695,24 @@ describe("services/navalclash/socialService", () => {
             })
         })
 
+        it("should allow chat-banned user to answer invitations (isbanned=16)", async () => {
+            mockExecute.mockResolvedValueOnce([
+                [{ id: 1, name: "ChatBanned", isbanned: 16 }],
+            ])
+
+            const req = {
+                requestId: "test",
+                body: { u: testUser, ans: true, usid: "1000" },
+            }
+
+            await userAnswer(req, mockRes)
+
+            // Chat ban should NOT trigger banned response (only game ban does)
+            expect(mockRes.json).not.toHaveBeenCalledWith(
+                expect.objectContaining({ type: "banned" })
+            )
+        })
+
         it("should send acceptance message to inviter", async () => {
             mockExecute
                 .mockResolvedValueOnce([
@@ -959,6 +977,25 @@ describe("services/navalclash/socialService", () => {
                 expect.stringContaining("target_rival_id"),
                 expect.anything()
             )
+        })
+
+        it("should check invitations for chat-banned user (isbanned=16)", async () => {
+            mockExecute
+                .mockResolvedValueOnce([
+                    [{ id: 10, name: "ChatBanned", isbanned: 16 }],
+                ]) // User lookup
+                .mockResolvedValueOnce([{ affectedRows: 1 }]) // UPDATE users (status)
+                .mockResolvedValueOnce([[]]) // No pending invitations
+
+            const req = {
+                requestId: "test",
+                body: { u: testUser, var: 1 },
+            }
+
+            await userMarker(req, mockRes)
+
+            // Chat ban should NOT block invitation checks (only game ban does)
+            expect(mockRes.json).toHaveBeenCalledWith({ type: "uok" })
         })
 
         it("should return uok when no pending invitation", async () => {

--- a/sql/navalclash/020_users_old_id.sql
+++ b/sql/navalclash/020_users_old_id.sql
@@ -1,0 +1,10 @@
+-- Naval Clash - Multiplayer Battleship Game
+-- Copyright (c) 2026 NorthernCaptain
+-- All rights reserved.
+
+-- Add old_id column to users table for mapping legacy user IDs
+ALTER TABLE users ADD COLUMN old_id INT UNSIGNED NULL AFTER id;
+ALTER TABLE users ADD KEY idx_old_id (old_id);
+
+-- Widen isbanned from TINYINT to SMALLINT UNSIGNED (legacy data uses bitmask values up to 4096)
+ALTER TABLE users MODIFY COLUMN isbanned SMALLINT UNSIGNED DEFAULT 0;


### PR DESCRIPTION
## Summary
- **Ban system**: Add bitmask-based ban support (game/scores/chat) with checks across connect, game, leaderboard, profile, and social services
- **Lang & version in leaderboard**: Include `lang` and `version` fields in leaderboard queries; update user `lang` on connect
- **CANCEL_SESSION IPC**: Immediately notify polling clients (errcode 5) when a session is closed by a departing player, instead of waiting for poll timeout
- **Tests**: Add comprehensive tests for CANCEL_SESSION IPC flow (clusterBroker, messageService) and ban-related logic across services

## Test plan
- [x] Unit tests added for CANCEL_SESSION in clusterBroker and messageService
- [x] Unit tests added for ban checks in connect, game, leaderboard, profile, and social services
- [ ] Run `npm test` to verify all tests pass
- [ ] Manual testing of ban enforcement on connect and game actions
- [ ] Verify leaderboard queries return lang/version fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)